### PR TITLE
#16 : Refresh Token 만료 시 로그아웃 처리 구현

### DIFF
--- a/android-app/src/main/AndroidManifest.xml
+++ b/android-app/src/main/AndroidManifest.xml
@@ -28,7 +28,7 @@
                 <category android:name="android.intent.category.BROWSABLE" />
 
                 <data android:host="oauth"
-                    android:scheme="${KAKAO_NATIVE_APP_KEY}" />
+                    android:scheme="kakao${KAKAO_NATIVE_APP_KEY}" />
             </intent-filter>
         </activity>
     </application>

--- a/android-app/src/main/AndroidManifest.xml
+++ b/android-app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.INTERNET"/>
 
     <application
         android:name=".BookPinApplication"

--- a/compose-app/build.gradle.kts
+++ b/compose-app/build.gradle.kts
@@ -31,6 +31,7 @@ kotlin {
             implementation(projects.auth)
             implementation(projects.designsystem)
             implementation(projects.common)
+            implementation(projects.model)
             implementation(projects.data)
             implementation(projects.domain)
             implementation(projects.dataApi)
@@ -40,6 +41,7 @@ kotlin {
 
             implementation(libs.kermit)
             implementation(libs.koin.core)
+            implementation(libs.koin.compose)
         }
         commonTest.dependencies {
             implementation(libs.kotlin.test)

--- a/compose-app/build.gradle.kts
+++ b/compose-app/build.gradle.kts
@@ -42,6 +42,7 @@ kotlin {
             implementation(libs.kermit)
             implementation(libs.koin.core)
             implementation(libs.koin.compose)
+            implementation(libs.koin.compose.viewmodel)
         }
         commonTest.dependencies {
             implementation(libs.kotlin.test)

--- a/compose-app/src/commonMain/kotlin/com/phase/bookpin/BookPinApp.kt
+++ b/compose-app/src/commonMain/kotlin/com/phase/bookpin/BookPinApp.kt
@@ -6,45 +6,34 @@ import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import com.phase.bookpin.auth.AuthScreen
+import com.phase.bookpin.common.extensions.collectSideEffect
 import com.phase.bookpin.common.snackbar.LocalSnackbarHost
 import com.phase.bookpin.designsystem.BookPinTheme
-import com.phase.bookpin.domain.session.SessionRepository
-import com.phase.bookpin.model.SessionEvent
-import kotlinx.coroutines.launch
-import org.koin.compose.koinInject
+import com.phase.bookpin.state.RootSideEffect
+import com.phase.bookpin.state.RootViewModel
+import org.koin.compose.viewmodel.koinViewModel
 import com.phase.bookpin.common.snackbar.SnackbarHost as BookPinSnackbarHost
 
 @Composable
-fun BookPinApp() {
-    val sessionRepository: SessionRepository = koinInject()
-
+fun BookPinApp(
+    viewModel: RootViewModel = koinViewModel(),
+) {
     BookPinTheme {
         val snackbarHostState = remember { SnackbarHostState() }
-        val scope = rememberCoroutineScope()
 
         val snackbarHost = object : BookPinSnackbarHost {
             override fun showSnackbar(message: String) {
-                scope.launch {
-                    snackbarHostState.showSnackbar(message)
-                }
+                viewModel.handleShowSnackbarEvent(message)
             }
         }
 
-        LaunchedEffect(Unit) {
-            sessionRepository.events.collect { event ->
-                when (event) {
-                    SessionEvent.SessionExpired,
-                    SessionEvent.InvalidRefreshToken,
-                    -> {
-                        sessionRepository.clearSession()
-                        snackbarHostState.showSnackbar("세션이 만료되었습니다. 다시 로그인해주세요.")
-                        // TODO: Navigation 구현 후 AuthScreen으로 이동
-                    }
+        viewModel.sideEffect.collectSideEffect { sideEffect ->
+            when (sideEffect) {
+                is RootSideEffect.ShowSnackbar -> {
+                    snackbarHostState.showSnackbar(sideEffect.message)
                 }
             }
         }

--- a/compose-app/src/commonMain/kotlin/com/phase/bookpin/BookPinApp.kt
+++ b/compose-app/src/commonMain/kotlin/com/phase/bookpin/BookPinApp.kt
@@ -6,17 +6,23 @@ import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import com.phase.bookpin.auth.AuthScreen
 import com.phase.bookpin.common.snackbar.LocalSnackbarHost
 import com.phase.bookpin.designsystem.BookPinTheme
+import com.phase.bookpin.domain.session.SessionRepository
+import com.phase.bookpin.model.SessionEvent
 import kotlinx.coroutines.launch
+import org.koin.compose.koinInject
 import com.phase.bookpin.common.snackbar.SnackbarHost as BookPinSnackbarHost
 
 @Composable
 fun BookPinApp() {
+    val sessionRepository: SessionRepository = koinInject()
+
     BookPinTheme {
         val snackbarHostState = remember { SnackbarHostState() }
         val scope = rememberCoroutineScope()
@@ -25,6 +31,20 @@ fun BookPinApp() {
             override fun showSnackbar(message: String) {
                 scope.launch {
                     snackbarHostState.showSnackbar(message)
+                }
+            }
+        }
+
+        LaunchedEffect(Unit) {
+            sessionRepository.events.collect { event ->
+                when (event) {
+                    SessionEvent.SessionExpired,
+                    SessionEvent.InvalidRefreshToken,
+                    -> {
+                        sessionRepository.clearSession()
+                        snackbarHostState.showSnackbar("세션이 만료되었습니다. 다시 로그인해주세요.")
+                        // TODO: Navigation 구현 후 AuthScreen으로 이동
+                    }
                 }
             }
         }

--- a/compose-app/src/commonMain/kotlin/com/phase/bookpin/di/AppModule.kt
+++ b/compose-app/src/commonMain/kotlin/com/phase/bookpin/di/AppModule.kt
@@ -6,6 +6,8 @@ import com.phase.bookpin.data.auth.com.phase.bookpin.data.auth.dataAuthModule
 import com.phase.bookpin.data.di.dataModule
 import com.phase.bookpin.data.local.di.dataLocalModule
 import com.phase.bookpin.data.remote.di.dataRemoteModule
+import com.phase.bookpin.state.RootViewModel
+import org.koin.core.module.dsl.viewModelOf
 import org.koin.dsl.module
 
 val appModule = module {
@@ -17,5 +19,6 @@ val appModule = module {
         dataRemoteModule,
     )
 
+    viewModelOf(::RootViewModel)
     single { Logger.withTag("BookPin") }
 }

--- a/compose-app/src/commonMain/kotlin/com/phase/bookpin/di/AppModule.kt
+++ b/compose-app/src/commonMain/kotlin/com/phase/bookpin/di/AppModule.kt
@@ -2,14 +2,10 @@ package com.phase.bookpin.di
 
 import co.touchlab.kermit.Logger
 import com.phase.bookpin.auth.di.authModule
-import com.phase.bookpin.data.api.navigation.Navigator
 import com.phase.bookpin.data.auth.com.phase.bookpin.data.auth.dataAuthModule
 import com.phase.bookpin.data.di.dataModule
 import com.phase.bookpin.data.local.di.dataLocalModule
 import com.phase.bookpin.data.remote.di.dataRemoteModule
-import com.phase.bookpin.navigation.NavigatorImpl
-import org.koin.core.module.dsl.bind
-import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.module
 
 val appModule = module {
@@ -21,6 +17,5 @@ val appModule = module {
         dataRemoteModule,
     )
 
-    singleOf(::NavigatorImpl) { bind<Navigator>() }
     single { Logger.withTag("BookPin") }
 }

--- a/compose-app/src/commonMain/kotlin/com/phase/bookpin/state/RootSideEffect.kt
+++ b/compose-app/src/commonMain/kotlin/com/phase/bookpin/state/RootSideEffect.kt
@@ -1,0 +1,7 @@
+package com.phase.bookpin.state
+
+sealed interface RootSideEffect {
+    data class ShowSnackbar(
+        val message: String,
+    ) : RootSideEffect
+}

--- a/compose-app/src/commonMain/kotlin/com/phase/bookpin/state/RootState.kt
+++ b/compose-app/src/commonMain/kotlin/com/phase/bookpin/state/RootState.kt
@@ -1,0 +1,3 @@
+package com.phase.bookpin.state
+
+class RootState

--- a/compose-app/src/commonMain/kotlin/com/phase/bookpin/state/RootViewModel.kt
+++ b/compose-app/src/commonMain/kotlin/com/phase/bookpin/state/RootViewModel.kt
@@ -1,0 +1,37 @@
+package com.phase.bookpin.state
+
+import androidx.lifecycle.viewModelScope
+import com.phase.bookpin.common.BaseViewModel
+import com.phase.bookpin.domain.session.SessionRepository
+import com.phase.bookpin.model.SessionEvent
+import kotlinx.coroutines.launch
+
+class RootViewModel(
+    private val sessionRepository: SessionRepository,
+) : BaseViewModel<RootState, RootSideEffect>() {
+    override fun createInitialState(): RootState = RootState()
+
+    init {
+        observeSessionEvents()
+    }
+
+    private fun observeSessionEvents() {
+        viewModelScope.launch {
+            sessionRepository.events.collect { event ->
+                when (event) {
+                    SessionEvent.SessionExpired,
+                    SessionEvent.InvalidRefreshToken,
+                    -> {
+                        sessionRepository.clearSession()
+                        postSideEffect(RootSideEffect.ShowSnackbar("세션이 만료되었습니다. 다시 로그인해주세요."))
+                        // TODO: Navigation 구현 후 AuthScreen으로 이동
+                    }
+                }
+            }
+        }
+    }
+
+    fun handleShowSnackbarEvent(message: String) {
+        postSideEffect(RootSideEffect.ShowSnackbar(message))
+    }
+}

--- a/data-api/src/commonMain/kotlin/com/phase/bookpin/data/api/session/SessionEventDataSource.kt
+++ b/data-api/src/commonMain/kotlin/com/phase/bookpin/data/api/session/SessionEventDataSource.kt
@@ -1,0 +1,10 @@
+package com.phase.bookpin.data.api.session
+
+import com.phase.bookpin.model.SessionEvent
+import kotlinx.coroutines.flow.Flow
+
+interface SessionEventDataSource {
+    val events: Flow<SessionEvent>
+    fun emitSessionExpired()
+    fun emitInvalidRefreshToken()
+}

--- a/data-remote/build.gradle.kts
+++ b/data-remote/build.gradle.kts
@@ -20,8 +20,8 @@ buildkonfig {
 
     defaultConfigs {
         buildConfigField(BOOLEAN, "IS_DEBUG", "false")
-        buildConfigField(STRING, "BASE_URL", "\"${localProperties.getProperty("BASE_URL", "https://api.bookpin.com/")}\"")
-        buildConfigField(STRING, "AMAZON_S3", "\"s3.ap-northeast-2.amazonaws.com/\"")
+        buildConfigField(STRING, "BASE_URL", localProperties.getProperty("BASE_URL", "https://api.bookpin.com/"))
+        buildConfigField(STRING, "AMAZON_S3", "s3.ap-northeast-2.amazonaws.com/")
     }
 
     defaultConfigs("debug") {

--- a/data-remote/build.gradle.kts
+++ b/data-remote/build.gradle.kts
@@ -59,6 +59,7 @@ kotlin {
             implementation(libs.ktor.client.core)
         }
         commonMain.dependencies {
+            implementation(projects.model)
             implementation(projects.dataApi)
             implementation(libs.kotlinx.coroutines)
             implementation(libs.kermit)

--- a/data-remote/src/commonMain/kotlin/com/phase/bookpin/data/remote/client/ClientModule.kt
+++ b/data-remote/src/commonMain/kotlin/com/phase/bookpin/data/remote/client/ClientModule.kt
@@ -4,6 +4,7 @@ import com.phase.bookpin.data.api.auth.RefreshTokenRequest
 import com.phase.bookpin.data.api.auth.RefreshTokenResponse
 import com.phase.bookpin.data.api.datastore.BookPinPreferenceDataStore
 import com.phase.bookpin.data.api.datastore.DataStoreKey
+import com.phase.bookpin.data.api.session.SessionEventDataSource
 import com.phase.bookpin.data.remote.BuildKonfig
 import com.phase.bookpin.data.remote.BuildKonfig.AMAZON_S3
 import io.ktor.client.HttpClient
@@ -37,6 +38,7 @@ expect fun createPlatformHttpClient(block: HttpClientConfig<*>.() -> Unit): Http
 internal fun createHttpClient(
     refreshClient: HttpClient,
     local: BookPinPreferenceDataStore,
+    sessionEventDataSource: SessionEventDataSource,
     logger: KermitLogger,
 ): HttpClient = createPlatformHttpClient {
 
@@ -52,7 +54,7 @@ internal fun createHttpClient(
             }
 
             refreshTokens {
-                refreshBearerTokens(refreshClient, local)
+                refreshBearerTokens(refreshClient, local, sessionEventDataSource)
             }
 
             sendWithoutRequest {
@@ -93,11 +95,18 @@ private suspend fun loadBearerTokens(
 private suspend fun refreshBearerTokens(
     refreshClient: HttpClient,
     local: BookPinPreferenceDataStore,
+    sessionEventDataSource: SessionEventDataSource,
 ): BearerTokens? {
-    if (isRefreshTokenExpired(local)) return null
+    if (isRefreshTokenExpired(local)) {
+        sessionEventDataSource.emitSessionExpired()
+        return null
+    }
 
     val refreshToken = local.getString(DataStoreKey.REFRESH_TOKEN).first()
-    if (refreshToken.isBlank()) return null
+    if (refreshToken.isBlank()) {
+        sessionEventDataSource.emitSessionExpired()
+        return null
+    }
 
     return runCatching {
         refreshClient.post {
@@ -108,6 +117,10 @@ private suspend fun refreshBearerTokens(
         local.saveString(DataStoreKey.ACCESS_TOKEN, response.accessToken)
         local.saveString(DataStoreKey.REFRESH_TOKEN, response.refreshToken)
         BearerTokens(response.accessToken, response.refreshToken)
+    }.onFailure { throwable ->
+        if (throwable.shouldLogoutOnRefreshFailure()) {
+            sessionEventDataSource.emitInvalidRefreshToken()
+        }
     }.getOrNull()
 }
 

--- a/data-remote/src/commonMain/kotlin/com/phase/bookpin/data/remote/client/SessionExtensions.kt
+++ b/data-remote/src/commonMain/kotlin/com/phase/bookpin/data/remote/client/SessionExtensions.kt
@@ -1,0 +1,6 @@
+package com.phase.bookpin.data.remote.client
+
+fun Throwable.shouldLogoutOnRefreshFailure(): Boolean {
+    if (this !is RemoteException) return false
+    return status == 401 || status == 403
+}

--- a/data-remote/src/commonMain/kotlin/com/phase/bookpin/data/remote/di/DataRemoteModule.kt
+++ b/data-remote/src/commonMain/kotlin/com/phase/bookpin/data/remote/di/DataRemoteModule.kt
@@ -1,21 +1,28 @@
 package com.phase.bookpin.data.remote.di
 
 import com.phase.bookpin.data.api.auth.AuthRemoteDataSource
+import com.phase.bookpin.data.api.session.SessionEventDataSource
 import com.phase.bookpin.data.remote.auth.AuthRemoteDataSourceImpl
 import com.phase.bookpin.data.remote.client.createHttpClient
 import com.phase.bookpin.data.remote.client.createRefreshHttpClient
+import com.phase.bookpin.data.remote.session.SessionEventDataSourceImpl
 import io.ktor.client.HttpClient
+import org.koin.core.module.dsl.bind
+import org.koin.core.module.dsl.singleOf
 import org.koin.core.qualifier.named
 import org.koin.dsl.module
 
 val RefreshHttpClient = named("RefreshHttpClient")
 
 val dataRemoteModule = module {
+    singleOf(::SessionEventDataSourceImpl) { bind<SessionEventDataSource>() }
+
     single(RefreshHttpClient) { createRefreshHttpClient(logger = get()) }
     single<HttpClient> {
         createHttpClient(
             refreshClient = get(RefreshHttpClient),
             local = get(),
+            sessionEventDataSource = get(),
             logger = get(),
         )
     }

--- a/data-remote/src/commonMain/kotlin/com/phase/bookpin/data/remote/session/SessionEventDataSourceImpl.kt
+++ b/data-remote/src/commonMain/kotlin/com/phase/bookpin/data/remote/session/SessionEventDataSourceImpl.kt
@@ -1,0 +1,20 @@
+package com.phase.bookpin.data.remote.session
+
+import com.phase.bookpin.data.api.session.SessionEventDataSource
+import com.phase.bookpin.model.SessionEvent
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+
+class SessionEventDataSourceImpl : SessionEventDataSource {
+    private val _events = MutableSharedFlow<SessionEvent>(extraBufferCapacity = 1)
+    override val events: Flow<SessionEvent> = _events.asSharedFlow()
+
+    override fun emitSessionExpired() {
+        _events.tryEmit(SessionEvent.SessionExpired)
+    }
+
+    override fun emitInvalidRefreshToken() {
+        _events.tryEmit(SessionEvent.InvalidRefreshToken)
+    }
+}

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -30,6 +30,7 @@ kotlin {
             implementation(projects.domain)
             implementation(projects.dataApi)
             implementation(libs.koin.core)
+            implementation(libs.kotlinx.coroutines)
         }
     }
 }

--- a/data/src/commonMain/kotlin/com/phase/bookpin/data/di/DataModule.kt
+++ b/data/src/commonMain/kotlin/com/phase/bookpin/data/di/DataModule.kt
@@ -1,11 +1,14 @@
 package com.phase.bookpin.data.di
 
 import com.phase.bookpin.data.auth.AuthRepositoryImpl
+import com.phase.bookpin.data.session.SessionRepositoryImpl
 import com.phase.bookpin.domain.auth.AuthRepository
+import com.phase.bookpin.domain.session.SessionRepository
 import org.koin.core.module.dsl.bind
 import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.module
 
 val dataModule = module {
     singleOf(::AuthRepositoryImpl) { bind<AuthRepository>() }
+    singleOf(::SessionRepositoryImpl) { bind<SessionRepository>() }
 }

--- a/data/src/commonMain/kotlin/com/phase/bookpin/data/session/SessionRepositoryImpl.kt
+++ b/data/src/commonMain/kotlin/com/phase/bookpin/data/session/SessionRepositoryImpl.kt
@@ -1,0 +1,19 @@
+package com.phase.bookpin.data.session
+
+import com.phase.bookpin.data.api.datastore.BookPinPreferenceDataStore
+import com.phase.bookpin.data.api.session.SessionEventDataSource
+import com.phase.bookpin.domain.session.SessionRepository
+import com.phase.bookpin.model.SessionEvent
+import kotlinx.coroutines.flow.Flow
+
+class SessionRepositoryImpl(
+    private val sessionEventDataSource: SessionEventDataSource,
+    private val preferenceDataStore: BookPinPreferenceDataStore,
+) : SessionRepository {
+
+    override val events: Flow<SessionEvent> = sessionEventDataSource.events
+
+    override suspend fun clearSession() {
+        preferenceDataStore.clear()
+    }
+}

--- a/domain/build.gradle.kts
+++ b/domain/build.gradle.kts
@@ -27,6 +27,7 @@ kotlin {
     sourceSets {
         commonMain.dependencies {
             implementation(projects.model)
+            implementation(libs.kotlinx.coroutines)
         }
     }
 }

--- a/domain/src/commonMain/kotlin/com/phase/bookpin/domain/session/SessionRepository.kt
+++ b/domain/src/commonMain/kotlin/com/phase/bookpin/domain/session/SessionRepository.kt
@@ -1,0 +1,9 @@
+package com.phase.bookpin.domain.session
+
+import com.phase.bookpin.model.SessionEvent
+import kotlinx.coroutines.flow.Flow
+
+interface SessionRepository {
+    val events: Flow<SessionEvent>
+    suspend fun clearSession()
+}

--- a/model/src/commonMain/kotlin/com/phase/bookpin/model/SessionEvent.kt
+++ b/model/src/commonMain/kotlin/com/phase/bookpin/model/SessionEvent.kt
@@ -1,0 +1,6 @@
+package com.phase.bookpin.model
+
+sealed interface SessionEvent {
+    data object SessionExpired : SessionEvent
+    data object InvalidRefreshToken : SessionEvent
+}


### PR DESCRIPTION
## 1. 📄 관련된 이슈 및 소개
- 관련 이슈: #16
- 소개: Refresh Token 만료 또는 갱신 실패 시 자동으로 세션을 정리하고 사용자에게 로그아웃을 알리는 기능을 구현합니다.

## 2. 🔥 변경된 점

### 새로운 파일 추가
- `model/SessionEvent.kt`: 세션 이벤트 sealed interface (SessionExpired, InvalidRefreshToken)
- `domain/session/SessionRepository.kt`: 세션 관리 Repository 인터페이스
- `data-api/session/SessionEventDataSource.kt`: 세션 이벤트 DataSource 인터페이스
- `data-remote/session/SessionEventDataSourceImpl.kt`: SharedFlow 기반 이벤트 구현체
- `data-remote/client/SessionExtensions.kt`: 로그아웃 판단 확장 함수
- `data/session/SessionRepositoryImpl.kt`: SessionRepository 구현체

### 기존 파일 수정
- `ClientModule.kt`: Refresh 토큰 만료/실패 시 SessionEventDataSource로 이벤트 emit
- `DataRemoteModule.kt`: SessionEventDataSourceImpl 싱글톤 등록
- `DataModule.kt`: SessionRepositoryImpl 싱글톤 등록
- `BookPinApp.kt`: LaunchedEffect로 세션 이벤트 수집 및 처리 (DataStore clear, 스낵바 표시)
- 각 모듈 `build.gradle.kts`: 필요한 의존성 추가

### 아키텍처
```
compose-app (UI) → domain (SessionRepository) → data (SessionRepositoryImpl)
                                                      ↓
                   data-api (SessionEventDataSource) ← data-remote (SessionEventDataSourceImpl)
                                                              ↑
                                               ClientModule (refresh 실패 감지)
```

## 3. ✅ 필수 체크 사항
- [x] 빌드 확인 (`./gradlew assembleDebug`)
- [x] KtLint 확인 (`./gradlew ktlintCheck`)
- [ ] 테스트 확인
- [ ] 코드 리뷰 요청

## 4. 📸 작업물 사진 공유(선택)
N/A (백엔드 로직 위주의 변경)

## 5. 💡 알게된 혹은 궁금한 사항
- Navigation 구현 후 AuthScreen으로 자동 이동하는 로직 추가 필요 (TODO로 남겨둠)
- Clean Architecture 원칙에 따라 계층 간 의존성 방향을 준수하여 구현

🤖 Generated with [Claude Code](https://claude.ai/code)