### PR TITLE
#26 : Settings 확인 모달 구현 및 KakaoAuth 연동

### DIFF
--- a/designsystem/src/commonMain/composeResources/drawable/ic_close.xml
+++ b/designsystem/src/commonMain/composeResources/drawable/ic_close.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#000000"
+        android:pathData="M18.3,5.71a0.996,0.996 0,0 0,-1.41 0L12,10.59 7.11,5.7A0.996,0.996 0,1 0,5.7 7.11L10.59,12 5.7,16.89a0.996,0.996 0,1 0,1.41 1.41L12,13.41l4.89,4.89a0.996,0.996 0,1 0,1.41 -1.41L13.41,12l4.89,-4.89c0.38,-0.38 0.38,-1.02 0,-1.4z"/>
+</vector>

--- a/designsystem/src/commonMain/kotlin/com/phase/bookpin/designsystem/Color.kt
+++ b/designsystem/src/commonMain/kotlin/com/phase/bookpin/designsystem/Color.kt
@@ -14,6 +14,7 @@ private val LightBrown = Color(0xFFA0826D)
 private val Placeholder = Color(0xFFD4B896)
 private val Teal = Color(0xFF9DBEB7)
 private val Peach = Color(0xFFE8B4A0)
+private val Terracotta = Color(0xFFD08C7E)
 
 @Immutable
 data class BookPinColors(
@@ -33,6 +34,7 @@ data class BookPinColors(
     val onSurfaceVariant: Color,
     val outline: Color,
     val outlineVariant: Color,
+    val error: Color,
 )
 
 internal val bookPinLightColors = BookPinColors(
@@ -52,6 +54,7 @@ internal val bookPinLightColors = BookPinColors(
     onSurfaceVariant = LightBrown,
     outline = Tan,
     outlineVariant = Placeholder,
+    error = Terracotta,
 )
 
 val LocalBookPinColors = staticCompositionLocalOf { bookPinLightColors }

--- a/designsystem/src/commonMain/kotlin/com/phase/bookpin/designsystem/component/BPConfirmDialog.kt
+++ b/designsystem/src/commonMain/kotlin/com/phase/bookpin/designsystem/component/BPConfirmDialog.kt
@@ -1,0 +1,116 @@
+package com.phase.bookpin.designsystem.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import bookpin.designsystem.generated.resources.Res
+import bookpin.designsystem.generated.resources.ic_close
+import com.phase.bookpin.designsystem.BookPinTheme
+import org.jetbrains.compose.resources.painterResource
+
+@Composable
+fun BPConfirmDialog(
+    title: String,
+    description: String,
+    cancelText: String,
+    confirmText: String,
+    confirmButtonColor: Color,
+    onDismiss: () -> Unit,
+    onConfirm: () -> Unit,
+) {
+    Dialog(onDismissRequest = onDismiss) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(24.dp))
+                .background(BookPinTheme.colors.background),
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(24.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                Spacer(modifier = Modifier.height(16.dp))
+
+                Text(
+                    text = title,
+                    style = BookPinTheme.typography.headlineMedium,
+                    color = BookPinTheme.colors.onSurface,
+                    textAlign = TextAlign.Center,
+                )
+
+                Spacer(modifier = Modifier.height(12.dp))
+
+                Text(
+                    text = description,
+                    style = BookPinTheme.typography.bodyMedium,
+                    color = BookPinTheme.colors.onSurfaceVariant,
+                    textAlign = TextAlign.Center,
+                )
+
+                Spacer(modifier = Modifier.height(24.dp))
+
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    Text(
+                        text = cancelText,
+                        style = BookPinTheme.typography.titleMedium,
+                        color = BookPinTheme.colors.onSurface,
+                        textAlign = TextAlign.Center,
+                        modifier = Modifier
+                            .weight(1f)
+                            .height(48.dp)
+                            .clip(RoundedCornerShape(16.dp))
+                            .clickable(onClick = onDismiss)
+                            .background(BookPinTheme.colors.surface)
+                            .wrapContentHeight(Alignment.CenterVertically),
+                    )
+
+                    Text(
+                        text = confirmText,
+                        style = BookPinTheme.typography.titleMedium,
+                        color = Color.White,
+                        textAlign = TextAlign.Center,
+                        modifier = Modifier
+                            .weight(1f)
+                            .height(48.dp)
+                            .clip(RoundedCornerShape(16.dp))
+                            .clickable(onClick = onConfirm)
+                            .background(confirmButtonColor)
+                            .wrapContentHeight(Alignment.CenterVertically),
+                    )
+                }
+            }
+
+            IconButton(
+                onClick = onDismiss,
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .padding(8.dp)
+                    .size(36.dp),
+            ) {
+                Icon(
+                    painter = painterResource(Res.drawable.ic_close),
+                    contentDescription = null,
+                    modifier = Modifier.size(20.dp),
+                    tint = BookPinTheme.colors.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}

--- a/settings/src/commonMain/composeResources/values/strings.xml
+++ b/settings/src/commonMain/composeResources/values/strings.xml
@@ -8,4 +8,11 @@
     <string name="logout">로그아웃</string>
     <string name="delete_account">회원 탈퇴</string>
     <string name="app_version">BookPin v1.0.0</string>
+    <string name="logout_title">로그아웃</string>
+    <string name="logout_description">로그아웃하면 저장된 로그인 정보가 삭제됩니다.\n다시 로그인하면 데이터를 복구할 수 있습니다.</string>
+    <string name="delete_account_title">계정 삭제</string>
+    <string name="delete_account_description">계정을 삭제하면 모든 데이터가 영구적으로 삭제됩니다.\n이 작업은 되돌릴 수 없습니다.</string>
+    <string name="cancel">취소</string>
+    <string name="confirm_logout">로그아웃</string>
+    <string name="confirm_delete">삭제하기</string>
 </resources>

--- a/settings/src/commonMain/kotlin/com/phase/bookpin/settings/SettingsScreen.kt
+++ b/settings/src/commonMain/kotlin/com/phase/bookpin/settings/SettingsScreen.kt
@@ -23,6 +23,7 @@ import bookpin.settings.generated.resources.*
 import com.phase.bookpin.common.extensions.collectSideEffect
 import com.phase.bookpin.common.snackbar.LocalSnackbarHost
 import com.phase.bookpin.designsystem.BookPinTheme
+import com.phase.bookpin.designsystem.component.BPConfirmDialog
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.viewmodel.koinViewModel
@@ -41,6 +42,7 @@ fun SettingsScreen(
             is SettingsSideEffect.ShowSnackbar -> snackbarHost.showSnackbar(it.message)
             SettingsSideEffect.NavigateBack -> onNavigateBack()
             SettingsSideEffect.Logout -> onLogout()
+            SettingsSideEffect.DeleteAccount -> onLogout()
         }
     }
 
@@ -84,6 +86,30 @@ fun SettingsScreen(
 
             Spacer(modifier = Modifier.height(24.dp))
         }
+    }
+
+    if (state.showLogoutDialog) {
+        BPConfirmDialog(
+            title = stringResource(Res.string.logout_title),
+            description = stringResource(Res.string.logout_description),
+            cancelText = stringResource(Res.string.cancel),
+            confirmText = stringResource(Res.string.confirm_logout),
+            confirmButtonColor = BookPinTheme.colors.primary,
+            onDismiss = viewModel::onLogoutDismiss,
+            onConfirm = viewModel::onLogoutConfirm,
+        )
+    }
+
+    if (state.showDeleteAccountDialog) {
+        BPConfirmDialog(
+            title = stringResource(Res.string.delete_account_title),
+            description = stringResource(Res.string.delete_account_description),
+            cancelText = stringResource(Res.string.cancel),
+            confirmText = stringResource(Res.string.confirm_delete),
+            confirmButtonColor = BookPinTheme.colors.error,
+            onDismiss = viewModel::onDeleteAccountDismiss,
+            onConfirm = viewModel::onDeleteAccountConfirm,
+        )
     }
 }
 

--- a/settings/src/commonMain/kotlin/com/phase/bookpin/settings/SettingsSideEffect.kt
+++ b/settings/src/commonMain/kotlin/com/phase/bookpin/settings/SettingsSideEffect.kt
@@ -6,4 +6,5 @@ sealed interface SettingsSideEffect {
     ) : SettingsSideEffect
     data object NavigateBack : SettingsSideEffect
     data object Logout : SettingsSideEffect
+    data object DeleteAccount : SettingsSideEffect
 }

--- a/settings/src/commonMain/kotlin/com/phase/bookpin/settings/SettingsState.kt
+++ b/settings/src/commonMain/kotlin/com/phase/bookpin/settings/SettingsState.kt
@@ -3,6 +3,8 @@ package com.phase.bookpin.settings
 data class SettingsState(
     val profileName: String = "독서하는 사람",
     val accountType: String = "카카오 계정",
+    val showLogoutDialog: Boolean = false,
+    val showDeleteAccountDialog: Boolean = false,
     val achievements: List<Achievement> = listOf(
         Achievement(
             emoji = "\uD83D\uDCD6",

--- a/settings/src/commonMain/kotlin/com/phase/bookpin/settings/SettingsViewModel.kt
+++ b/settings/src/commonMain/kotlin/com/phase/bookpin/settings/SettingsViewModel.kt
@@ -1,8 +1,11 @@
 package com.phase.bookpin.settings
 
 import com.phase.bookpin.common.BaseViewModel
+import com.phase.bookpin.domain.kakao.KakaoAuth
 
-class SettingsViewModel : BaseViewModel<SettingsState, SettingsSideEffect>() {
+class SettingsViewModel(
+    private val kakaoAuth: KakaoAuth,
+) : BaseViewModel<SettingsState, SettingsSideEffect>() {
     override fun createInitialState(): SettingsState = SettingsState()
 
     fun onBackClick() {
@@ -14,10 +17,30 @@ class SettingsViewModel : BaseViewModel<SettingsState, SettingsSideEffect>() {
     }
 
     fun onLogoutClick() {
+        reduce { copy(showLogoutDialog = true) }
+    }
+
+    fun onLogoutDismiss() {
+        reduce { copy(showLogoutDialog = false) }
+    }
+
+    fun onLogoutConfirm() {
+        reduce { copy(showLogoutDialog = false) }
+        kakaoAuth.logout()
         postSideEffect(SettingsSideEffect.Logout)
     }
 
     fun onDeleteAccountClick() {
-        postSideEffect(SettingsSideEffect.ShowSnackbar("회원 탈퇴 기능은 준비 중입니다."))
+        reduce { copy(showDeleteAccountDialog = true) }
+    }
+
+    fun onDeleteAccountDismiss() {
+        reduce { copy(showDeleteAccountDialog = false) }
+    }
+
+    fun onDeleteAccountConfirm() {
+        reduce { copy(showDeleteAccountDialog = false) }
+        kakaoAuth.revoke()
+        postSideEffect(SettingsSideEffect.DeleteAccount)
     }
 }


### PR DESCRIPTION
## 1. 📄 관련된 이슈 및 소개
- 관련 이슈: #26
- 소개: Settings 화면에서 로그아웃/회원 탈퇴 클릭 시 확인 모달을 표시하고, 확인 시 KakaoAuth를 통해 로그아웃/계정 삭제를 수행합니다. 모달은 디자인 시스템 공용 컴포넌트(`BPConfirmDialog`)로 구현했습니다.

## 2. 🔥 변경된 점
### designsystem
- `BookPinColors`에 `error` 색상(Terracotta `#D08C7E`) 추가
- `ic_close.xml` 아이콘 리소스 추가
- `BPConfirmDialog` 공용 확인 모달 컴포넌트 신규 구현
  - 반투명 오버레이, rounded 24dp 카드, X 닫기 버튼
  - 취소/확인 버튼 쌍 (rounded 16dp, height 48dp)
  - `confirmButtonColor` 파라미터로 버튼 색상 커스터마이징 가능

### settings
- `SettingsState`에 `showLogoutDialog`, `showDeleteAccountDialog` 상태 추가
- `SettingsSideEffect`에 `DeleteAccount` 추가
- `SettingsViewModel`에 `KakaoAuth` 주입 및 다이얼로그 표시/확인/취소 로직 구현
  - 로그아웃 확인 → `kakaoAuth.logout()` → `Logout` SideEffect
  - 회원 탈퇴 확인 → `kakaoAuth.revoke()` → `DeleteAccount` SideEffect
- `SettingsScreen`에 `BPConfirmDialog` 연동
  - 로그아웃 모달: 확인 버튼 Gold(`primary`)
  - 회원 탈퇴 모달: 확인 버튼 Terracotta(`error`)
- 모달 문자열 리소스 추가 (제목, 설명, 취소, 확인)

## 3. ✅ 필수 체크 사항
- [ ] 빌드 확인
- [ ] 테스트 확인
- [ ] 코드 리뷰 요청

## 4. 📸 작업물 사진 공유(선택)

## 5. 💡 알게된 혹은 궁금한 사항
- `BPConfirmDialog`는 디자인 시스템 공용 컴포넌트로 구현하여 다른 Feature 모듈에서도 재사용 가능합니다.
- `DeleteAccount` SideEffect 처리 시 `onLogout()`을 호출하여 AuthRoute로 이동합니다.