### PR TITLE
홈 화면 책장 API 연동 및 UI 리팩토링

### DIFF
--- a/compose-app/src/commonMain/kotlin/com/phase/bookpin/BookPinApp.kt
+++ b/compose-app/src/commonMain/kotlin/com/phase/bookpin/BookPinApp.kt
@@ -66,6 +66,7 @@ fun BookPinApp(
             Scaffold(
                 snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
                 modifier = Modifier.fillMaxSize(),
+                containerColor = BookPinTheme.colors.bgCanvas,
             ) {
                 BookPinNavHost(
                     backStack = backStack,

--- a/compose-app/src/commonMain/kotlin/com/phase/bookpin/navigation/BookPinNavHost.kt
+++ b/compose-app/src/commonMain/kotlin/com/phase/bookpin/navigation/BookPinNavHost.kt
@@ -16,7 +16,7 @@ fun BookPinNavHost(
     backStack: NavBackStack<NavKey>,
     onNavigateToHome: () -> Unit,
     onNavigateToSearch: () -> Unit,
-    onNavigateToBookDetail: (String) -> Unit,
+    onNavigateToBookDetail: (Long) -> Unit,
     onNavigateToSettings: () -> Unit,
     onNavigateBack: () -> Unit,
     onLogout: () -> Unit,

--- a/compose-app/src/commonMain/kotlin/com/phase/bookpin/navigation/Route.kt
+++ b/compose-app/src/commonMain/kotlin/com/phase/bookpin/navigation/Route.kt
@@ -16,7 +16,7 @@ data object SearchRoute : NavKey
 
 @Serializable
 data class BookDetailRoute(
-    val bookId: String,
+    val bookId: Long,
 ) : NavKey
 
 @Serializable

--- a/core/data-api/src/commonMain/kotlin/com/phase/bookpin/data/api/book/BookItemResponse.kt
+++ b/core/data-api/src/commonMain/kotlin/com/phase/bookpin/data/api/book/BookItemResponse.kt
@@ -1,0 +1,27 @@
+package com.phase.bookpin.data.api.book
+
+import com.phase.bookpin.model.book.BookItem
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class BookItemResponse(
+    val id: Long,
+    val title: String,
+    val author: String,
+    val imageUrl: String,
+    val totalPage: Int,
+    val currentPage: Int,
+    val progress: Double,
+    val bookmarkCount: Int,
+) {
+    fun toBookItem(): BookItem = BookItem(
+        id = id,
+        title = title,
+        author = author,
+        imageUrl = imageUrl,
+        totalPage = totalPage,
+        currentPage = currentPage,
+        progress = progress,
+        bookmarkCount = bookmarkCount,
+    )
+}

--- a/core/data-api/src/commonMain/kotlin/com/phase/bookpin/data/api/book/BookRemoteDataSource.kt
+++ b/core/data-api/src/commonMain/kotlin/com/phase/bookpin/data/api/book/BookRemoteDataSource.kt
@@ -1,0 +1,5 @@
+package com.phase.bookpin.data.api.book
+
+interface BookRemoteDataSource {
+    suspend fun getBookItems(): Result<List<BookItemResponse>>
+}

--- a/core/data-remote/src/commonMain/kotlin/com/phase/bookpin/data/remote/book/BookRemoteDataSourceImpl.kt
+++ b/core/data-remote/src/commonMain/kotlin/com/phase/bookpin/data/remote/book/BookRemoteDataSourceImpl.kt
@@ -1,0 +1,20 @@
+package com.phase.bookpin.data.remote.book
+
+import com.phase.bookpin.data.api.book.BookItemResponse
+import com.phase.bookpin.data.api.book.BookRemoteDataSource
+import com.phase.bookpin.data.remote.client.safeRequest
+import io.ktor.client.HttpClient
+import io.ktor.http.HttpMethod
+import io.ktor.http.path
+
+class BookRemoteDataSourceImpl(
+    private val httpClient: HttpClient,
+): BookRemoteDataSource {
+    override suspend fun getBookItems(): Result<List<BookItemResponse>> =
+        httpClient.safeRequest {
+            url {
+                method = HttpMethod.Get
+                path("api/v1/books")
+            }
+        }
+}

--- a/core/data-remote/src/commonMain/kotlin/com/phase/bookpin/data/remote/client/ClientModule.kt
+++ b/core/data-remote/src/commonMain/kotlin/com/phase/bookpin/data/remote/client/ClientModule.kt
@@ -41,7 +41,6 @@ internal fun createHttpClient(
     sessionEventListener: SessionEventListener,
     logger: KermitLogger,
 ): HttpClient = createPlatformHttpClient {
-
     defaultRequest {
         header(HttpHeaders.ContentType, ContentType.Application.Json)
         url(BuildKonfig.BASE_URL)
@@ -100,11 +99,6 @@ private suspend fun refreshBearerTokens(
     local: BookPinPreferenceDataStore,
     listener: SessionEventListener,
 ): BearerTokens? {
-    if (isRefreshTokenExpired(local)) {
-        listener.onSessionExpired()
-        return null
-    }
-
     val refreshToken = local.getString(DataStoreKey.REFRESH_TOKEN).first()
     if (refreshToken.isNullOrEmpty()) {
         listener.onSessionExpired()
@@ -121,7 +115,7 @@ private suspend fun refreshBearerTokens(
         local.saveString(DataStoreKey.REFRESH_TOKEN, response.refreshToken)
         BearerTokens(response.accessToken, response.refreshToken)
     }.onFailure { throwable ->
-        if (throwable.shouldLogoutOnRefreshFailure()) {
+        if (throwable.shouldReAuthenticateFailure()) {
             listener.onInvalidRefreshToken()
         }
     }.getOrNull()
@@ -153,16 +147,7 @@ internal fun createRefreshHttpClient(logger: KermitLogger): HttpClient = createP
     }
 }
 
-private suspend fun isRefreshTokenExpired(local: BookPinPreferenceDataStore): Boolean {
-    val expiredAt = local
-        .getString(DataStoreKey.REFRESH_TOKEN_EXPIRED_AT)
-        .first()
-
-    if (expiredAt.isNullOrEmpty()) {
-        return true
-    }
-
-    return runCatching {
-        Instant.parse(expiredAt) <= Clock.System.now()
-    }.getOrDefault(true)
+private fun Throwable.shouldReAuthenticateFailure(): Boolean {
+    if (this !is RemoteException) return false
+    return status == 401 || status == 403
 }

--- a/core/data-remote/src/commonMain/kotlin/com/phase/bookpin/data/remote/client/SessionExtensions.kt
+++ b/core/data-remote/src/commonMain/kotlin/com/phase/bookpin/data/remote/client/SessionExtensions.kt
@@ -1,6 +1,0 @@
-package com.phase.bookpin.data.remote.client
-
-fun Throwable.shouldLogoutOnRefreshFailure(): Boolean {
-    if (this !is RemoteException) return false
-    return status == 401 || status == 403
-}

--- a/core/data-remote/src/commonMain/kotlin/com/phase/bookpin/data/remote/di/DataRemoteModule.kt
+++ b/core/data-remote/src/commonMain/kotlin/com/phase/bookpin/data/remote/di/DataRemoteModule.kt
@@ -1,7 +1,9 @@
 package com.phase.bookpin.data.remote.di
 
 import com.phase.bookpin.data.api.auth.AuthRemoteDataSource
+import com.phase.bookpin.data.api.book.BookRemoteDataSource
 import com.phase.bookpin.data.remote.auth.AuthRemoteDataSourceImpl
+import com.phase.bookpin.data.remote.book.BookRemoteDataSourceImpl
 import com.phase.bookpin.data.remote.client.createHttpClient
 import com.phase.bookpin.data.remote.client.createRefreshHttpClient
 import io.ktor.client.HttpClient
@@ -22,8 +24,9 @@ val dataRemoteModule = module {
     }
 
     single<AuthRemoteDataSource> {
-        AuthRemoteDataSourceImpl(
-            client = get(),
-        )
+        AuthRemoteDataSourceImpl(client = get())
+    }
+    single<BookRemoteDataSource> {
+        BookRemoteDataSourceImpl(httpClient = get())
     }
 }

--- a/core/data/src/commonMain/kotlin/com/phase/bookpin/data/book/BookRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/com/phase/bookpin/data/book/BookRepositoryImpl.kt
@@ -1,0 +1,17 @@
+package com.phase.bookpin.data.book
+
+import com.phase.bookpin.data.api.book.BookRemoteDataSource
+import com.phase.bookpin.domain.book.BookRepository
+import com.phase.bookpin.model.book.BookItem
+
+class BookRepositoryImpl(
+    private val dataSource: BookRemoteDataSource,
+): BookRepository {
+    override suspend fun getBookItems(): Result<List<BookItem>> {
+        return dataSource.getBookItems().mapCatching { responses ->
+            responses.map {
+                it.toBookItem()
+            }
+        }
+    }
+}

--- a/core/data/src/commonMain/kotlin/com/phase/bookpin/data/di/DataModule.kt
+++ b/core/data/src/commonMain/kotlin/com/phase/bookpin/data/di/DataModule.kt
@@ -3,9 +3,11 @@ package com.phase.bookpin.data.di
 import com.phase.bookpin.data.api.auth.SessionEventListener
 import com.phase.bookpin.data.auth.AuthRepositoryImpl
 import com.phase.bookpin.data.auth.SessionRepositoryImpl
+import com.phase.bookpin.data.book.BookRepositoryImpl
 import com.phase.bookpin.data.device.DeviceRepositoryImpl
 import com.phase.bookpin.domain.auth.AuthRepository
 import com.phase.bookpin.domain.auth.SessionRepository
+import com.phase.bookpin.domain.book.BookRepository
 import com.phase.bookpin.domain.device.DeviceRepository
 import org.koin.core.module.dsl.bind
 import org.koin.core.module.dsl.singleOf
@@ -18,4 +20,5 @@ val dataModule = module {
         bind<SessionEventListener>()
     }
     singleOf(::DeviceRepositoryImpl) { bind<DeviceRepository>() }
+    singleOf(::BookRepositoryImpl) { bind<BookRepository>() }
 }

--- a/designsystem/src/commonMain/kotlin/com/phase/bookpin/designsystem/Type.kt
+++ b/designsystem/src/commonMain/kotlin/com/phase/bookpin/designsystem/Type.kt
@@ -99,8 +99,8 @@ internal fun bookPinTypography(): BookPinTypography {
             titleLarge = TextStyle(
                 fontFamily = appleFontFamily,
                 fontWeight = FontWeight.Bold,
-                fontSize = 20.sp,
-                lineHeight = 28.sp,
+                fontSize = 18.sp,
+                lineHeight = 26.sp,
             ),
             titleMedium = TextStyle(
                 fontFamily = appleFontFamily,

--- a/designsystem/src/commonMain/kotlin/com/phase/bookpin/designsystem/common/BookCoverColorPicker.kt
+++ b/designsystem/src/commonMain/kotlin/com/phase/bookpin/designsystem/common/BookCoverColorPicker.kt
@@ -1,6 +1,7 @@
 package com.phase.bookpin.designsystem.common
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.Color
 import com.phase.bookpin.designsystem.BookPinTheme
 import kotlin.math.absoluteValue
@@ -15,8 +16,13 @@ object BookCoverColorPicker {
     }
 
     @Composable
-    private fun palette(): List<Color> = listOf(
-        BookPinTheme.colors.accentPrimary,
-        BookPinTheme.colors.accentSecondary,
-    )
+    private fun palette(): List<Color> {
+        val colors = BookPinTheme.colors
+        return remember(colors) {
+            listOf(
+                colors.accentPrimary,
+                colors.accentSecondary,
+            )
+        }
+    }
 }

--- a/designsystem/src/commonMain/kotlin/com/phase/bookpin/designsystem/common/BookCoverColorPicker.kt
+++ b/designsystem/src/commonMain/kotlin/com/phase/bookpin/designsystem/common/BookCoverColorPicker.kt
@@ -1,0 +1,22 @@
+package com.phase.bookpin.designsystem.common
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import com.phase.bookpin.designsystem.BookPinTheme
+import kotlin.math.absoluteValue
+
+object BookCoverColorPicker {
+
+    @Composable
+    fun pick(bookId: Long): Color {
+        val colors = palette()
+        val index = bookId.hashCode().absoluteValue % colors.size
+        return colors[index]
+    }
+
+    @Composable
+    private fun palette(): List<Color> = listOf(
+        BookPinTheme.colors.accentPrimary,
+        BookPinTheme.colors.accentSecondary,
+    )
+}

--- a/designsystem/src/commonMain/kotlin/com/phase/bookpin/designsystem/component/BPLoadingScreen.kt
+++ b/designsystem/src/commonMain/kotlin/com/phase/bookpin/designsystem/component/BPLoadingScreen.kt
@@ -1,0 +1,25 @@
+package com.phase.bookpin.designsystem.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import com.phase.bookpin.designsystem.BookPinTheme
+
+@Composable
+fun BPLoadingScreen(modifier: Modifier = Modifier) {
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .background(BookPinTheme.colors.bgCanvas),
+        contentAlignment = Alignment.Center,
+    ) {
+        CircularProgressIndicator(
+            color = BookPinTheme.colors.buttonPrimary,
+            trackColor = BookPinTheme.colors.bgSurface,
+        )
+    }
+}

--- a/domain/src/commonMain/kotlin/com/phase/bookpin/domain/book/BookRepository.kt
+++ b/domain/src/commonMain/kotlin/com/phase/bookpin/domain/book/BookRepository.kt
@@ -1,0 +1,7 @@
+package com.phase.bookpin.domain.book
+
+import com.phase.bookpin.model.book.BookItem
+
+interface BookRepository {
+    suspend fun getBookItems(): Result<List<BookItem>>
+}

--- a/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/BookDetailScreen.kt
+++ b/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/BookDetailScreen.kt
@@ -36,7 +36,7 @@ import org.koin.compose.viewmodel.koinViewModel
 
 @Composable
 fun BookDetailScreen(
-    bookId: String,
+    bookId: Long,
     onNavigateBack: () -> Unit = {},
 ) {
     val viewModel: BookDetailViewModel = koinViewModel()

--- a/feature/home/build.gradle.kts
+++ b/feature/home/build.gradle.kts
@@ -41,6 +41,7 @@ kotlin {
             implementation(projects.model)
             implementation(projects.domain)
             implementation(libs.koin.compose.viewmodel)
+            implementation(libs.coil.compose)
         }
         commonTest.dependencies {
             implementation(libs.kotlin.test)

--- a/feature/home/src/commonMain/composeResources/values/strings.xml
+++ b/feature/home/src/commonMain/composeResources/values/strings.xml
@@ -8,7 +8,7 @@
     <string name="reading_days">%d일째</string>
     <string name="empty_reading_title">BookPin이 처음이신가요?</string>
     <string name="empty_reading_subtitle">내 책장에 책 추가하기</string>
-    <string name="empty_bookshelf">추가된 책이 없습니다.</string>
+    <string name="empty_bookshelf">추가된 책이 없습니다. \n 책 추가 버튼을 통해 책을 추가해보세요!</string>
     <string name="unknown_error_message">알 수 없는 예외가 발생하였습니다</string>
 
     <!-- Content Descriptions -->

--- a/feature/home/src/commonMain/composeResources/values/strings.xml
+++ b/feature/home/src/commonMain/composeResources/values/strings.xml
@@ -9,6 +9,7 @@
     <string name="empty_reading_title">BookPin이 처음이신가요?</string>
     <string name="empty_reading_subtitle">내 책장에 책 추가하기</string>
     <string name="empty_bookshelf">추가된 책이 없습니다.</string>
+    <string name="unknown_error_message">알 수 없는 예외가 발생하였습니다</string>
 
     <!-- Content Descriptions -->
     <string name="cd_bookpin_icon">BookPin 아이콘</string>

--- a/feature/home/src/commonMain/kotlin/com/phase/bookpin/home/HomeScreen.kt
+++ b/feature/home/src/commonMain/kotlin/com/phase/bookpin/home/HomeScreen.kt
@@ -1,70 +1,42 @@
 package com.phase.bookpin.home
 
-import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.background
-import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
-import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.shadow
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import bookpin.home.generated.resources.Res
-import bookpin.home.generated.resources.add
-import bookpin.home.generated.resources.add_book
-import bookpin.home.generated.resources.app_name
-import bookpin.home.generated.resources.bookmark
-import bookpin.home.generated.resources.cd_bookmark
-import bookpin.home.generated.resources.cd_settings
-import bookpin.home.generated.resources.chevron_right
 import bookpin.home.generated.resources.currently_reading
 import bookpin.home.generated.resources.empty_bookshelf
-import bookpin.home.generated.resources.empty_reading_subtitle
-import bookpin.home.generated.resources.empty_reading_title
-import bookpin.home.generated.resources.leave_bookmark
 import bookpin.home.generated.resources.my_bookshelf
-import bookpin.home.generated.resources.setting
 import com.phase.bookpin.common.extensions.collectSideEffect
 import com.phase.bookpin.common.snackbar.LocalSnackbarHost
 import com.phase.bookpin.designsystem.BookPinTheme
+import com.phase.bookpin.designsystem.component.BPLoadingScreen
+import com.phase.bookpin.home.component.BookAddButton
+import com.phase.bookpin.home.component.BookItemCard
+import com.phase.bookpin.home.component.CurrentlyReadingCard
+import com.phase.bookpin.home.component.HomeTopBar
 import com.phase.bookpin.model.book.BookItem
 import org.jetbrains.compose.resources.getString
-import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.viewmodel.koinViewModel
-import kotlin.math.absoluteValue
 
 @Composable
 fun HomeScreen(
@@ -101,63 +73,30 @@ fun HomeScreen(
                 onClick = viewModel::onAddBookClick,
             )
         },
-        containerColor = BookPinTheme.colors.bgCanvas,
     ) { innerPadding ->
+        if (state.isLoading) {
+            BPLoadingScreen(modifier = Modifier.padding(innerPadding))
+            return@Scaffold
+        }
+
         Column(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(innerPadding)
                 .padding(horizontal = 20.dp),
+            verticalArrangement = Arrangement.spacedBy(24.dp),
         ) {
-            CurrentlyReadingSection(
-                book = state.bookItems.firstOrNull(),
-                onAddBookmarkClick = { state.bookItems.firstOrNull()?.let { viewModel.onAddBookmarkClick(it.id) } },
-                onAddBookClick = viewModel::onAddBookClick,
-            )
-
-            Spacer(modifier = Modifier.height(32.dp))
+            val currentReadingBook = state.bookItems.firstOrNull()
+            AnimatedVisibility(currentReadingBook != null) {
+                CurrentlyReadingSection(
+                    bookItem = requireNotNull(currentReadingBook),
+                    onAddBookmarkClick = { state.bookItems.firstOrNull()?.let { viewModel.onAddBookmarkClick(it.id) } },
+                )
+            }
 
             BookShelfSection(
-                books = state.bookItems,
+                bookItems = state.bookItems,
                 onBookClick = viewModel::onBookClick,
-            )
-
-            Spacer(modifier = Modifier.height(24.dp))
-        }
-    }
-}
-
-@Composable
-private fun HomeTopBar(
-    onSettingsClick: () -> Unit,
-) {
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(20.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.SpaceBetween,
-    ) {
-        Text(
-            text = stringResource(Res.string.app_name),
-            style = BookPinTheme.typography.headlineLarge,
-            color = BookPinTheme.colors.textPrimary,
-        )
-
-        IconButton(
-            onClick = onSettingsClick,
-            modifier = Modifier
-                .size(36.dp)
-                .background(
-                    color = BookPinTheme.colors.bgSurface,
-                    shape = CircleShape,
-                ),
-        ) {
-            Icon(
-                painter = painterResource(Res.drawable.setting),
-                contentDescription = stringResource(Res.string.cd_settings),
-                modifier = Modifier.size(20.dp),
-                tint = BookPinTheme.colors.iconDefault,
             )
         }
     }
@@ -165,436 +104,64 @@ private fun HomeTopBar(
 
 @Composable
 private fun CurrentlyReadingSection(
-    book: BookItem?,
+    bookItem: BookItem,
     onAddBookmarkClick: () -> Unit,
-    onAddBookClick: () -> Unit,
 ) {
-    Text(
-        text = stringResource(Res.string.currently_reading),
-        style = BookPinTheme.typography.titleLarge,
-        color = BookPinTheme.colors.textPrimary,
-    )
+    Column {
+        Text(
+            text = stringResource(Res.string.currently_reading),
+            style = BookPinTheme.typography.titleLarge,
+            color = BookPinTheme.colors.textPrimary,
+        )
 
-    Spacer(modifier = Modifier.height(16.dp))
+        Spacer(modifier = Modifier.height(16.dp))
 
-    if (book != null) {
         CurrentlyReadingCard(
-            book = book,
+            bookItem = bookItem,
             onAddBookmarkClick = onAddBookmarkClick,
         )
-    } else {
-        EmptyReadingCard(onClick = onAddBookClick)
-    }
-}
-
-@Composable
-private fun BookAddButton(
-    onClick: () -> Unit,
-) {
-    Button(
-        onClick = onClick,
-        shape = CircleShape,
-        colors = ButtonDefaults.buttonColors(
-            containerColor = BookPinTheme.colors.bgMuted,
-            contentColor = BookPinTheme.colors.textPrimary,
-        ),
-        elevation = ButtonDefaults.buttonElevation(
-            defaultElevation = 2.dp,
-            pressedElevation = 6.dp,
-        ),
-        contentPadding = PaddingValues(horizontal = 16.dp, vertical = 10.dp),
-    ) {
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(4.dp),
-        ) {
-            Icon(
-                painter = painterResource(Res.drawable.add),
-                contentDescription = null,
-                modifier = Modifier.size(16.dp),
-            )
-            Text(
-                text = stringResource(Res.string.add_book),
-                style = BookPinTheme.typography.titleMedium,
-            )
-        }
-    }
-}
-
-@Composable
-private fun EmptyReadingCard(
-    onClick: () -> Unit,
-) {
-    Card(
-        onClick = onClick,
-        modifier = Modifier
-            .fillMaxWidth()
-            .shadow(
-                elevation = 2.dp,
-                shape = RoundedCornerShape(16.dp),
-                ambientColor = BookPinTheme.colors.shadow.copy(alpha = 0.06f),
-                spotColor = BookPinTheme.colors.shadow.copy(alpha = 0.06f),
-            ),
-        shape = RoundedCornerShape(16.dp),
-        colors = CardDefaults.cardColors(containerColor = BookPinTheme.colors.bgElevated),
-        border = BorderStroke(
-            width = 0.615.dp,
-            color = BookPinTheme.colors.borderDefault,
-        ),
-    ) {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 20.dp, vertical = 20.dp),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            Column(modifier = Modifier.weight(1f)) {
-                Text(
-                    text = stringResource(Res.string.empty_reading_title),
-                    style = BookPinTheme.typography.bodyLarge,
-                    color = BookPinTheme.colors.textPrimary,
-                )
-
-                Spacer(modifier = Modifier.height(4.dp))
-
-                Text(
-                    text = stringResource(Res.string.empty_reading_subtitle),
-                    style = BookPinTheme.typography.bodySmall,
-                    color = BookPinTheme.colors.textTertiary,
-                )
-            }
-
-            Icon(
-                painter = painterResource(Res.drawable.chevron_right),
-                contentDescription = null,
-                modifier = Modifier.size(20.dp),
-                tint = BookPinTheme.colors.iconDefault,
-            )
-        }
-    }
-}
-
-@Composable
-private fun CurrentlyReadingCard(
-    book: BookItem,
-    onAddBookmarkClick: () -> Unit,
-) {
-    val coverColors = listOf(
-        BookPinTheme.colors.accentPrimary,
-        BookPinTheme.colors.accentSecondary,
-    )
-    val colorIndex = book.id.hashCode().absoluteValue % coverColors.size
-
-    Box(
-        modifier = Modifier
-            .fillMaxWidth()
-            .shadow(
-                elevation = 8.dp,
-                shape = RoundedCornerShape(28.dp),
-                ambientColor = BookPinTheme.colors.shadow.copy(alpha = 0.06f),
-                spotColor = BookPinTheme.colors.shadow.copy(alpha = 0.06f),
-            ).background(
-                color = BookPinTheme.colors.bgElevated,
-                shape = RoundedCornerShape(28.dp),
-            ).border(
-                width = 0.615.dp,
-                color = BookPinTheme.colors.bgSurface,
-                shape = RoundedCornerShape(28.dp),
-            ).padding(24.dp),
-    ) {
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-        ) {
-            Box(
-                modifier = Modifier
-                    .width(96.dp)
-                    .height(144.dp)
-                    .shadow(
-                        elevation = 4.dp,
-                        shape = RoundedCornerShape(12.dp),
-                    ).background(
-                        color = coverColors[colorIndex],
-                        shape = RoundedCornerShape(12.dp),
-                    ).clip(RoundedCornerShape(12.dp)),
-                contentAlignment = Alignment.Center,
-            ) {
-                Text(
-                    text = book.title.take(2),
-                    style = BookPinTheme.typography.bodyLarge,
-                    color = BookPinTheme.colors.textOnAccent.copy(alpha = 0.5f),
-                )
-            }
-
-            Spacer(modifier = Modifier.width(20.dp))
-
-            Column(
-                modifier = Modifier
-                    .weight(1f)
-                    .height(144.dp),
-            ) {
-                Text(
-                    text = book.title,
-                    style = BookPinTheme.typography.bodyLarge,
-                    color = BookPinTheme.colors.textPrimary,
-                    maxLines = 1,
-                )
-
-                Spacer(modifier = Modifier.height(4.dp))
-
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(6.dp),
-                ) {
-                    Text(
-                        text = book.author,
-                        style = BookPinTheme.typography.titleSmall,
-                        color = BookPinTheme.colors.textSecondary,
-                    )
-
-                    Box(
-                        modifier = Modifier
-                            .size(4.dp)
-                            .background(
-                                color = BookPinTheme.colors.borderDefault,
-                                shape = CircleShape,
-                            ),
-                    )
-
-                    Text(
-                        text = "${book.bookmarkCount} 개",
-                        style = BookPinTheme.typography.labelMedium,
-                        color = BookPinTheme.colors.textAccent,
-                    )
-                }
-
-                Spacer(modifier = Modifier.weight(1f))
-
-                Row(
-                    verticalAlignment = Alignment.Bottom,
-                ) {
-                    Text(
-                        text = "${book.currentPage}p / ${book.totalPage}p ",
-                        style = BookPinTheme.typography.titleSmall,
-                        color = BookPinTheme.colors.textSecondary,
-                    )
-
-                    Text(
-                        text = "${book.progress}%",
-                        style = BookPinTheme.typography.titleSmall,
-                        color = BookPinTheme.colors.textAccent,
-                    )
-                }
-
-                Spacer(modifier = Modifier.height(8.dp))
-
-                Box(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(6.dp)
-                        .background(
-                            color = BookPinTheme.colors.bgSurface,
-                            shape = CircleShape,
-                        ),
-                ) {
-                    Box(
-                        modifier = Modifier
-                            .fillMaxHeight()
-                            .fillMaxWidth((book.progress / 100f).toFloat())
-                            .background(
-                                color = BookPinTheme.colors.buttonPrimary,
-                                shape = CircleShape,
-                            ),
-                    )
-                }
-
-                Spacer(modifier = Modifier.height(16.dp))
-
-                Button(
-                    onClick = onAddBookmarkClick,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(32.dp),
-                    shape = RoundedCornerShape(16.dp),
-                    colors = ButtonDefaults.buttonColors(
-                        containerColor = BookPinTheme.colors.bgMuted,
-                    ),
-                    elevation = ButtonDefaults.buttonElevation(
-                        defaultElevation = 2.dp,
-                        pressedElevation = 6.dp,
-                    ),
-                    contentPadding = PaddingValues(0.dp),
-                ) {
-                    Text(
-                        text = stringResource(Res.string.leave_bookmark),
-                        style = BookPinTheme.typography.labelMedium,
-                        color = BookPinTheme.colors.textPrimary,
-                    )
-                }
-            }
-        }
     }
 }
 
 @Composable
 private fun BookShelfSection(
-    books: List<BookItem>,
+    bookItems: List<BookItem>,
     onBookClick: (Long) -> Unit,
 ) {
-    Text(
-        text = stringResource(Res.string.my_bookshelf),
-        style = BookPinTheme.typography.titleLarge,
-        color = BookPinTheme.colors.textPrimary,
-    )
+    Column {
+        Text(
+            text = stringResource(Res.string.my_bookshelf),
+            style = BookPinTheme.typography.titleLarge,
+            color = BookPinTheme.colors.textPrimary,
+        )
 
-    Spacer(modifier = Modifier.height(16.dp))
+        Spacer(modifier = Modifier.height(16.dp))
 
-    if (books.isNotEmpty()) {
+        if (bookItems.isEmpty()) {
+            Text(
+                text = stringResource(Res.string.empty_bookshelf),
+                style = BookPinTheme.typography.titleSmall,
+                color = BookPinTheme.colors.textSecondary,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 24.dp),
+                textAlign = TextAlign.Center,
+            )
+            return
+        }
+
         LazyVerticalGrid(
             columns = GridCells.Fixed(2),
             contentPadding = PaddingValues(bottom = 16.dp),
             horizontalArrangement = Arrangement.spacedBy(12.dp),
             verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
-            items(books, key = { it.id }) { book ->
-                BookCard(
-                    book = book,
-                    onClick = { onBookClick(book.id) },
+            items(bookItems, key = { it.id }) { bookItem ->
+                BookItemCard(
+                    bookItem = bookItem,
+                    onClick = { onBookClick(bookItem.id) },
                 )
             }
-        }
-    } else {
-        Text(
-            text = stringResource(Res.string.empty_bookshelf),
-            style = BookPinTheme.typography.titleSmall,
-            color = BookPinTheme.colors.textSecondary,
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(vertical = 24.dp),
-            textAlign = TextAlign.Center,
-        )
-    }
-}
-
-@Composable
-private fun BookCard(
-    book: BookItem,
-    onClick: () -> Unit,
-) {
-    val coverColors = listOf(
-        BookPinTheme.colors.accentPrimary,
-        BookPinTheme.colors.accentSecondary,
-    )
-    val colorIndex = book.id.hashCode().absoluteValue % coverColors.size
-
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .shadow(
-                elevation = 2.dp,
-                shape = RoundedCornerShape(16.dp),
-            ).background(
-                color = BookPinTheme.colors.bgElevated,
-                shape = RoundedCornerShape(16.dp),
-            ).clickable(onClick = onClick)
-            .padding(16.dp),
-    ) {
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(128.dp)
-                .background(
-                    color = coverColors[colorIndex],
-                    shape = RoundedCornerShape(16.dp),
-                ).clip(RoundedCornerShape(16.dp)),
-            contentAlignment = Alignment.Center,
-        ) {
-            Text(
-                text = book.title.take(2),
-                style = BookPinTheme.typography.bodyLarge,
-                color = BookPinTheme.colors.textOnAccent.copy(alpha = 0.5f),
-            )
-        }
-
-        Spacer(
-            modifier = Modifier.height(
-                12.dp,
-            ),
-        )
-
-        Text(
-            text = book.title,
-            style = BookPinTheme.typography.titleSmall,
-            color = BookPinTheme.colors.textPrimary,
-            maxLines = 1,
-        )
-
-        Text(
-            text = book.author,
-            style = BookPinTheme.typography.bodySmall,
-            color = BookPinTheme.colors.textSecondary,
-        )
-
-        Spacer(modifier = Modifier.height(12.dp))
-
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            verticalAlignment = Alignment.Bottom,
-            horizontalArrangement = Arrangement.SpaceBetween,
-        ) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Text(
-                    text = "${book.currentPage} / ${book.totalPage} ",
-                    style = BookPinTheme.typography.labelSmall,
-                    color = BookPinTheme.colors.textSecondary,
-                )
-
-                Text(
-                    text = "(${book.progress}%)",
-                    style = BookPinTheme.typography.labelMedium,
-                    color = BookPinTheme.colors.textAccent,
-                )
-            }
-
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(4.dp),
-                modifier = Modifier.padding(start = 4.dp),
-            ) {
-                Icon(
-                    painter = painterResource(Res.drawable.bookmark),
-                    contentDescription = stringResource(Res.string.cd_bookmark),
-                    modifier = Modifier.size(14.dp),
-                    tint = Color.Unspecified,
-                )
-
-                Text(
-                    text = "${book.bookmarkCount}",
-                    style = BookPinTheme.typography.labelMedium,
-                    color = BookPinTheme.colors.textPrimary.copy(alpha = 0.8f),
-                )
-            }
-        }
-
-        Spacer(modifier = Modifier.height(8.dp))
-
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(6.dp)
-                .background(
-                    color = BookPinTheme.colors.bgSurface,
-                    shape = CircleShape,
-                ),
-        ) {
-            Box(
-                modifier = Modifier
-                    .fillMaxHeight()
-                    .fillMaxWidth((book.progress / 100f).toFloat())
-                    .background(
-                        color = BookPinTheme.colors.buttonPrimary,
-                        shape = CircleShape,
-                    ),
-            )
         }
     }
 }

--- a/feature/home/src/commonMain/kotlin/com/phase/bookpin/home/HomeScreen.kt
+++ b/feature/home/src/commonMain/kotlin/com/phase/bookpin/home/HomeScreen.kt
@@ -90,7 +90,7 @@ fun HomeScreen(
             AnimatedVisibility(currentReadingBook != null) {
                 CurrentlyReadingSection(
                     bookItem = requireNotNull(currentReadingBook),
-                    onAddBookmarkClick = { state.bookItems.firstOrNull()?.let { viewModel.onAddBookmarkClick(it.id) } },
+                    onAddBookmarkClick = { viewModel.onAddBookmarkClick(currentReadingBook.id) },
                 )
             }
 

--- a/feature/home/src/commonMain/kotlin/com/phase/bookpin/home/HomeScreen.kt
+++ b/feature/home/src/commonMain/kotlin/com/phase/bookpin/home/HomeScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -58,6 +59,8 @@ import bookpin.home.generated.resources.setting
 import com.phase.bookpin.common.extensions.collectSideEffect
 import com.phase.bookpin.common.snackbar.LocalSnackbarHost
 import com.phase.bookpin.designsystem.BookPinTheme
+import com.phase.bookpin.model.book.BookItem
+import org.jetbrains.compose.resources.getString
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.viewmodel.koinViewModel
@@ -67,7 +70,7 @@ import kotlin.math.absoluteValue
 fun HomeScreen(
     viewModel: HomeViewModel = koinViewModel(),
     onNavigateToSearch: () -> Unit = {},
-    onNavigateToBookDetail: (String) -> Unit = {},
+    onNavigateToBookDetail: (Long) -> Unit = {},
     onNavigateToSettings: () -> Unit = {},
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
@@ -76,13 +79,17 @@ fun HomeScreen(
     viewModel.sideEffect.collectSideEffect {
         when (it) {
             is HomeSideEffect.ShowSnackbar -> {
-                snackbarHost.showSnackbar(it.message)
+                snackbarHost.showSnackbar(getString(it.message))
             }
             HomeSideEffect.NavigateToSettings -> onNavigateToSettings()
             is HomeSideEffect.NavigateToBookDetail -> onNavigateToBookDetail(it.bookId)
             is HomeSideEffect.NavigateToAddBookmark -> {}
             HomeSideEffect.NavigateToAddBook -> onNavigateToSearch()
         }
+    }
+
+    LaunchedEffect(Unit) {
+        viewModel.onEnterScreen()
     }
 
     Scaffold(
@@ -103,15 +110,15 @@ fun HomeScreen(
                 .padding(horizontal = 20.dp),
         ) {
             CurrentlyReadingSection(
-                book = state.books.firstOrNull(),
-                onAddBookmarkClick = { state.books.firstOrNull()?.let { viewModel.onAddBookmarkClick(it.id) } },
+                book = state.bookItems.firstOrNull(),
+                onAddBookmarkClick = { state.bookItems.firstOrNull()?.let { viewModel.onAddBookmarkClick(it.id) } },
                 onAddBookClick = viewModel::onAddBookClick,
             )
 
             Spacer(modifier = Modifier.height(32.dp))
 
             BookShelfSection(
-                books = state.books,
+                books = state.bookItems,
                 onBookClick = viewModel::onBookClick,
             )
 
@@ -158,7 +165,7 @@ private fun HomeTopBar(
 
 @Composable
 private fun CurrentlyReadingSection(
-    book: Book?,
+    book: BookItem?,
     onAddBookmarkClick: () -> Unit,
     onAddBookClick: () -> Unit,
 ) {
@@ -269,7 +276,7 @@ private fun EmptyReadingCard(
 
 @Composable
 private fun CurrentlyReadingCard(
-    book: Book,
+    book: BookItem,
     onAddBookmarkClick: () -> Unit,
 ) {
     val coverColors = listOf(
@@ -354,7 +361,7 @@ private fun CurrentlyReadingCard(
                     )
 
                     Text(
-                        text = "${book.readingDays}일째",
+                        text = "${book.bookmarkCount} 개",
                         style = BookPinTheme.typography.labelMedium,
                         color = BookPinTheme.colors.textAccent,
                     )
@@ -366,13 +373,13 @@ private fun CurrentlyReadingCard(
                     verticalAlignment = Alignment.Bottom,
                 ) {
                     Text(
-                        text = "${book.currentPage}p / ${book.totalPages}p ",
+                        text = "${book.currentPage}p / ${book.totalPage}p ",
                         style = BookPinTheme.typography.titleSmall,
                         color = BookPinTheme.colors.textSecondary,
                     )
 
                     Text(
-                        text = "${book.progressPercent}%",
+                        text = "${book.progress}%",
                         style = BookPinTheme.typography.titleSmall,
                         color = BookPinTheme.colors.textAccent,
                     )
@@ -392,7 +399,7 @@ private fun CurrentlyReadingCard(
                     Box(
                         modifier = Modifier
                             .fillMaxHeight()
-                            .fillMaxWidth(book.progressPercent / 100f)
+                            .fillMaxWidth((book.progress / 100f).toFloat())
                             .background(
                                 color = BookPinTheme.colors.buttonPrimary,
                                 shape = CircleShape,
@@ -430,8 +437,8 @@ private fun CurrentlyReadingCard(
 
 @Composable
 private fun BookShelfSection(
-    books: List<Book>,
-    onBookClick: (String) -> Unit,
+    books: List<BookItem>,
+    onBookClick: (Long) -> Unit,
 ) {
     Text(
         text = stringResource(Res.string.my_bookshelf),
@@ -470,7 +477,7 @@ private fun BookShelfSection(
 
 @Composable
 private fun BookCard(
-    book: Book,
+    book: BookItem,
     onClick: () -> Unit,
 ) {
     val coverColors = listOf(
@@ -508,7 +515,11 @@ private fun BookCard(
             )
         }
 
-        Spacer(modifier = Modifier.height(12.dp))
+        Spacer(
+            modifier = Modifier.height(
+                12.dp,
+            ),
+        )
 
         Text(
             text = book.title,
@@ -532,13 +543,13 @@ private fun BookCard(
         ) {
             Row(verticalAlignment = Alignment.CenterVertically) {
                 Text(
-                    text = "${book.currentPage} / ${book.totalPages} ",
+                    text = "${book.currentPage} / ${book.totalPage} ",
                     style = BookPinTheme.typography.labelSmall,
                     color = BookPinTheme.colors.textSecondary,
                 )
 
                 Text(
-                    text = "(${book.progressPercent}%)",
+                    text = "(${book.progress}%)",
                     style = BookPinTheme.typography.labelMedium,
                     color = BookPinTheme.colors.textAccent,
                 )
@@ -578,7 +589,7 @@ private fun BookCard(
             Box(
                 modifier = Modifier
                     .fillMaxHeight()
-                    .fillMaxWidth(book.progressPercent / 100f)
+                    .fillMaxWidth((book.progress / 100f).toFloat())
                     .background(
                         color = BookPinTheme.colors.buttonPrimary,
                         shape = CircleShape,

--- a/feature/home/src/commonMain/kotlin/com/phase/bookpin/home/HomeScreen.kt
+++ b/feature/home/src/commonMain/kotlin/com/phase/bookpin/home/HomeScreen.kt
@@ -164,7 +164,7 @@ private fun CurrentlyReadingSection(
 ) {
     Text(
         text = stringResource(Res.string.currently_reading),
-        style = BookPinTheme.typography.headlineMedium,
+        style = BookPinTheme.typography.titleLarge,
         color = BookPinTheme.colors.textPrimary,
     )
 
@@ -244,7 +244,7 @@ private fun EmptyReadingCard(
             Column(modifier = Modifier.weight(1f)) {
                 Text(
                     text = stringResource(Res.string.empty_reading_title),
-                    style = BookPinTheme.typography.titleLarge,
+                    style = BookPinTheme.typography.bodyLarge,
                     color = BookPinTheme.colors.textPrimary,
                 )
 
@@ -252,7 +252,7 @@ private fun EmptyReadingCard(
 
                 Text(
                     text = stringResource(Res.string.empty_reading_subtitle),
-                    style = BookPinTheme.typography.titleSmall,
+                    style = BookPinTheme.typography.bodySmall,
                     color = BookPinTheme.colors.textTertiary,
                 )
             }
@@ -313,7 +313,7 @@ private fun CurrentlyReadingCard(
             ) {
                 Text(
                     text = book.title.take(2),
-                    style = BookPinTheme.typography.headlineSmall,
+                    style = BookPinTheme.typography.bodyLarge,
                     color = BookPinTheme.colors.textOnAccent.copy(alpha = 0.5f),
                 )
             }
@@ -327,7 +327,7 @@ private fun CurrentlyReadingCard(
             ) {
                 Text(
                     text = book.title,
-                    style = BookPinTheme.typography.headlineSmall,
+                    style = BookPinTheme.typography.bodyLarge,
                     color = BookPinTheme.colors.textPrimary,
                     maxLines = 1,
                 )
@@ -435,7 +435,7 @@ private fun BookShelfSection(
 ) {
     Text(
         text = stringResource(Res.string.my_bookshelf),
-        style = BookPinTheme.typography.headlineSmall,
+        style = BookPinTheme.typography.titleLarge,
         color = BookPinTheme.colors.textPrimary,
     )
 
@@ -503,7 +503,7 @@ private fun BookCard(
         ) {
             Text(
                 text = book.title.take(2),
-                style = BookPinTheme.typography.titleLarge,
+                style = BookPinTheme.typography.bodyLarge,
                 color = BookPinTheme.colors.textOnAccent.copy(alpha = 0.5f),
             )
         }
@@ -519,7 +519,7 @@ private fun BookCard(
 
         Text(
             text = book.author,
-            style = BookPinTheme.typography.labelMedium,
+            style = BookPinTheme.typography.bodySmall,
             color = BookPinTheme.colors.textSecondary,
         )
 

--- a/feature/home/src/commonMain/kotlin/com/phase/bookpin/home/HomeScreen.kt
+++ b/feature/home/src/commonMain/kotlin/com/phase/bookpin/home/HomeScreen.kt
@@ -88,9 +88,10 @@ fun HomeScreen(
         ) {
             val currentReadingBook = state.bookItems.firstOrNull()
             AnimatedVisibility(currentReadingBook != null) {
+                val book = currentReadingBook ?: return@AnimatedVisibility
                 CurrentlyReadingSection(
-                    bookItem = requireNotNull(currentReadingBook),
-                    onAddBookmarkClick = { viewModel.onAddBookmarkClick(currentReadingBook.id) },
+                    bookItem = book,
+                    onAddBookmarkClick = { viewModel.onAddBookmarkClick(book.id) },
                 )
             }
 

--- a/feature/home/src/commonMain/kotlin/com/phase/bookpin/home/HomeSideEffect.kt
+++ b/feature/home/src/commonMain/kotlin/com/phase/bookpin/home/HomeSideEffect.kt
@@ -1,15 +1,17 @@
 package com.phase.bookpin.home
 
+import org.jetbrains.compose.resources.StringResource
+
 sealed interface HomeSideEffect {
     data class ShowSnackbar(
-        val message: String,
+        val message: StringResource,
     ) : HomeSideEffect
     data object NavigateToSettings : HomeSideEffect
     data class NavigateToBookDetail(
-        val bookId: String,
+        val bookId: Long,
     ) : HomeSideEffect
     data object NavigateToAddBook : HomeSideEffect
     data class NavigateToAddBookmark(
-        val bookId: String,
+        val bookId: Long,
     ) : HomeSideEffect
 }

--- a/feature/home/src/commonMain/kotlin/com/phase/bookpin/home/HomeState.kt
+++ b/feature/home/src/commonMain/kotlin/com/phase/bookpin/home/HomeState.kt
@@ -1,19 +1,7 @@
 package com.phase.bookpin.home
 
-data class HomeState(
-    val books: List<Book> = emptyList(),
-)
+import com.phase.bookpin.model.book.BookItem
 
-data class Book(
-    val id: String = "",
-    val title: String = "",
-    val author: String = "",
-    val coverImageUrl: String = "",
-    val currentPage: Int = 0,
-    val totalPages: Int = 0,
-    val bookmarkCount: Int = 0,
-    val readingDays: Int = 0,
-) {
-    val progressPercent: Int
-        get() = if (totalPages > 0) (currentPage * 100 / totalPages) else 0
-}
+data class HomeState(
+    val books: List<BookItem> = emptyList(),
+)

--- a/feature/home/src/commonMain/kotlin/com/phase/bookpin/home/HomeState.kt
+++ b/feature/home/src/commonMain/kotlin/com/phase/bookpin/home/HomeState.kt
@@ -3,5 +3,6 @@ package com.phase.bookpin.home
 import com.phase.bookpin.model.book.BookItem
 
 data class HomeState(
-    val books: List<BookItem> = emptyList(),
+    val isLoading: Boolean = false,
+    val bookItems: List<BookItem> = emptyList(),
 )

--- a/feature/home/src/commonMain/kotlin/com/phase/bookpin/home/HomeViewModel.kt
+++ b/feature/home/src/commonMain/kotlin/com/phase/bookpin/home/HomeViewModel.kt
@@ -1,31 +1,38 @@
 package com.phase.bookpin.home
 
+import androidx.lifecycle.viewModelScope
+import bookpin.home.generated.resources.Res
+import bookpin.home.generated.resources.unknown_error_message
 import com.phase.bookpin.common.BaseViewModel
+import com.phase.bookpin.domain.book.BookRepository
+import kotlinx.coroutines.launch
 
-class HomeViewModel : BaseViewModel<HomeState, HomeSideEffect>() {
-    override fun createInitialState(): HomeState = HomeState(
-        books = listOf(
-            Book(
-                id = "1",
-                title = "미드나잇 라이브러리",
-                author = "매트 헤이그",
-                coverImageUrl = "",
-                currentPage = 208,
-                totalPages = 320,
-                bookmarkCount = 12,
-                readingDays = 1,
-            ),
-            Book(
-                id = "2",
-                title = "아주 작은 습관의 힘",
-                author = "제임스 클리어",
-                coverImageUrl = "",
-                currentPage = 112,
-                totalPages = 280,
-                bookmarkCount = 8,
-            ),
-        ),
-    )
+class HomeViewModel(
+    private val bookRepository: BookRepository,
+) : BaseViewModel<HomeState, HomeSideEffect>() {
+    override fun createInitialState(): HomeState = HomeState()
+
+    fun onEnterScreen() {
+        reduce {
+            state.copy(isLoading = true)
+        }
+
+        viewModelScope.launch {
+            bookRepository
+                .getBookItems()
+                .onSuccess { items ->
+                    reduce {
+                        state.copy(bookItems = items)
+                    }
+                }.onFailure {
+                    postSideEffect(
+                        HomeSideEffect.ShowSnackbar(Res.string.unknown_error_message),
+                    )
+                }.also {
+                    reduce { state.copy(isLoading = false) }
+                }
+        }
+    }
 
     fun onSettingsClick() {
         postSideEffect(HomeSideEffect.NavigateToSettings)
@@ -35,11 +42,11 @@ class HomeViewModel : BaseViewModel<HomeState, HomeSideEffect>() {
         postSideEffect(HomeSideEffect.NavigateToAddBook)
     }
 
-    fun onBookClick(bookId: String) {
+    fun onBookClick(bookId: Long) {
         postSideEffect(HomeSideEffect.NavigateToBookDetail(bookId))
     }
 
-    fun onAddBookmarkClick(bookId: String) {
+    fun onAddBookmarkClick(bookId: Long) {
         postSideEffect(HomeSideEffect.NavigateToAddBookmark(bookId))
     }
 }

--- a/feature/home/src/commonMain/kotlin/com/phase/bookpin/home/component/BookAddButton.kt
+++ b/feature/home/src/commonMain/kotlin/com/phase/bookpin/home/component/BookAddButton.kt
@@ -1,0 +1,55 @@
+package com.phase.bookpin.home.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import bookpin.home.generated.resources.Res
+import bookpin.home.generated.resources.add
+import bookpin.home.generated.resources.add_book
+import com.phase.bookpin.designsystem.BookPinTheme
+import org.jetbrains.compose.resources.painterResource
+import org.jetbrains.compose.resources.stringResource
+
+@Composable
+internal fun BookAddButton(
+    onClick: () -> Unit,
+) {
+    Button(
+        onClick = onClick,
+        shape = CircleShape,
+        colors = ButtonDefaults.buttonColors(
+            containerColor = BookPinTheme.colors.bgMuted,
+            contentColor = BookPinTheme.colors.textPrimary,
+        ),
+        elevation = ButtonDefaults.buttonElevation(
+            defaultElevation = 2.dp,
+            pressedElevation = 6.dp,
+        ),
+        contentPadding = PaddingValues(horizontal = 16.dp, vertical = 10.dp),
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            Icon(
+                painter = painterResource(Res.drawable.add),
+                contentDescription = null,
+                modifier = Modifier.size(16.dp),
+            )
+            Text(
+                text = stringResource(Res.string.add_book),
+                style = BookPinTheme.typography.titleMedium,
+            )
+        }
+    }
+}

--- a/feature/home/src/commonMain/kotlin/com/phase/bookpin/home/component/BookItemCard.kt
+++ b/feature/home/src/commonMain/kotlin/com/phase/bookpin/home/component/BookItemCard.kt
@@ -1,0 +1,142 @@
+package com.phase.bookpin.home.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import bookpin.home.generated.resources.Res
+import bookpin.home.generated.resources.bookmark
+import bookpin.home.generated.resources.cd_bookmark
+import coil3.compose.AsyncImage
+import com.phase.bookpin.designsystem.BookPinTheme
+import com.phase.bookpin.model.book.BookItem
+import org.jetbrains.compose.resources.painterResource
+import org.jetbrains.compose.resources.stringResource
+
+@Composable
+internal fun BookItemCard(
+    bookItem: BookItem,
+    onClick: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .shadow(
+                elevation = 2.dp,
+                shape = RoundedCornerShape(16.dp),
+            ).background(
+                color = BookPinTheme.colors.bgElevated,
+                shape = RoundedCornerShape(16.dp),
+            ).clickable(onClick = onClick)
+            .padding(16.dp),
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(128.dp),
+            contentAlignment = Alignment.Center,
+        ) {
+            AsyncImage(
+                modifier = Modifier.shadow(elevation = 4.dp),
+                model = bookItem.imageUrl,
+                contentDescription = null,
+            )
+        }
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        Text(
+            text = bookItem.title,
+            style = BookPinTheme.typography.titleSmall,
+            color = BookPinTheme.colors.textPrimary,
+            maxLines = 1,
+        )
+
+        Text(
+            text = bookItem.author,
+            style = BookPinTheme.typography.bodySmall,
+            color = BookPinTheme.colors.textSecondary,
+        )
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.Bottom,
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    text = "${bookItem.currentPage} / ${bookItem.totalPage} ",
+                    style = BookPinTheme.typography.labelSmall,
+                    color = BookPinTheme.colors.textSecondary,
+                )
+
+                Text(
+                    text = "(${bookItem.progress}%)",
+                    style = BookPinTheme.typography.labelMedium,
+                    color = BookPinTheme.colors.textAccent,
+                )
+            }
+
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(4.dp),
+                modifier = Modifier.padding(start = 4.dp),
+            ) {
+                Icon(
+                    painter = painterResource(Res.drawable.bookmark),
+                    contentDescription = stringResource(Res.string.cd_bookmark),
+                    modifier = Modifier.size(14.dp),
+                    tint = Color.Unspecified,
+                )
+
+                Text(
+                    text = "${bookItem.bookmarkCount}",
+                    style = BookPinTheme.typography.labelMedium,
+                    color = BookPinTheme.colors.textPrimary.copy(alpha = 0.8f),
+                )
+            }
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(6.dp)
+                .background(
+                    color = BookPinTheme.colors.bgSurface,
+                    shape = CircleShape,
+                ),
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxHeight()
+                    .fillMaxWidth((bookItem.progress / 100f).toFloat())
+                    .background(
+                        color = BookPinTheme.colors.buttonPrimary,
+                        shape = CircleShape,
+                    ),
+            )
+        }
+    }
+}

--- a/feature/home/src/commonMain/kotlin/com/phase/bookpin/home/component/BookItemCard.kt
+++ b/feature/home/src/commonMain/kotlin/com/phase/bookpin/home/component/BookItemCard.kt
@@ -39,10 +39,7 @@ internal fun BookItemCard(
     Column(
         modifier = Modifier
             .fillMaxWidth()
-            .shadow(
-                elevation = 2.dp,
-                shape = RoundedCornerShape(16.dp),
-            ).background(
+            .background(
                 color = BookPinTheme.colors.bgElevated,
                 shape = RoundedCornerShape(16.dp),
             ).clickable(onClick = onClick)

--- a/feature/home/src/commonMain/kotlin/com/phase/bookpin/home/component/BookItemCard.kt
+++ b/feature/home/src/commonMain/kotlin/com/phase/bookpin/home/component/BookItemCard.kt
@@ -128,7 +128,7 @@ internal fun BookItemCard(
             Box(
                 modifier = Modifier
                     .fillMaxHeight()
-                    .fillMaxWidth((bookItem.progress / 100f).toFloat())
+                    .fillMaxWidth((bookItem.progress / 100.0).toFloat())
                     .background(
                         color = BookPinTheme.colors.buttonPrimary,
                         shape = CircleShape,

--- a/feature/home/src/commonMain/kotlin/com/phase/bookpin/home/component/CurrentReadingCard.kt
+++ b/feature/home/src/commonMain/kotlin/com/phase/bookpin/home/component/CurrentReadingCard.kt
@@ -1,0 +1,187 @@
+package com.phase.bookpin.home.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import bookpin.home.generated.resources.Res
+import bookpin.home.generated.resources.bookmark
+import bookpin.home.generated.resources.cd_bookmark
+import bookpin.home.generated.resources.leave_bookmark
+import coil3.compose.AsyncImage
+import com.phase.bookpin.designsystem.BookPinTheme
+import com.phase.bookpin.model.book.BookItem
+import org.jetbrains.compose.resources.painterResource
+import org.jetbrains.compose.resources.stringResource
+
+@Composable
+internal fun CurrentlyReadingCard(
+    bookItem: BookItem,
+    onAddBookmarkClick: () -> Unit,
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(
+                color = BookPinTheme.colors.bgElevated,
+                shape = RoundedCornerShape(28.dp),
+            ).border(
+                width = 1.dp,
+                color = BookPinTheme.colors.bgSurface,
+                shape = RoundedCornerShape(28.dp),
+            ).padding(24.dp),
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Box(
+                modifier = Modifier
+                    .height(144.dp)
+                    .shadow(elevation = 4.dp),
+                contentAlignment = Alignment.Center,
+            ) {
+                AsyncImage(
+                    model = bookItem.imageUrl,
+                    contentDescription = null,
+                )
+            }
+
+            Spacer(modifier = Modifier.width(20.dp))
+
+            Column {
+                Text(
+                    text = bookItem.title,
+                    style = BookPinTheme.typography.bodyLarge,
+                    color = BookPinTheme.colors.textPrimary,
+                    maxLines = 2,
+                )
+
+                Spacer(modifier = Modifier.height(4.dp))
+
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(6.dp),
+                ) {
+                    Text(
+                        text = bookItem.author,
+                        style = BookPinTheme.typography.titleSmall,
+                        color = BookPinTheme.colors.textSecondary,
+                    )
+
+                    Box(
+                        modifier = Modifier
+                            .size(4.dp)
+                            .background(
+                                color = BookPinTheme.colors.borderDefault,
+                                shape = CircleShape,
+                            ),
+                    )
+
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(4.dp),
+                        modifier = Modifier.padding(start = 4.dp),
+                    ) {
+                        Icon(
+                            painter = painterResource(Res.drawable.bookmark),
+                            contentDescription = stringResource(Res.string.cd_bookmark),
+                            modifier = Modifier.size(14.dp),
+                            tint = Color.Unspecified,
+                        )
+
+                        Text(
+                            text = "${bookItem.bookmarkCount}",
+                            style = BookPinTheme.typography.labelMedium,
+                            color = BookPinTheme.colors.textPrimary.copy(alpha = 0.8f),
+                        )
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.Bottom,
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                ) {
+                    Text(
+                        text = "${bookItem.currentPage}p / ${bookItem.totalPage}p ",
+                        style = BookPinTheme.typography.titleSmall,
+                        color = BookPinTheme.colors.textSecondary,
+                    )
+
+                    Text(
+                        text = "${bookItem.progress}%",
+                        style = BookPinTheme.typography.bodyLarge,
+                        color = BookPinTheme.colors.textAccent,
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(6.dp)
+                        .background(
+                            color = BookPinTheme.colors.bgSurface,
+                            shape = CircleShape,
+                        ),
+                ) {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxHeight()
+                            .fillMaxWidth((bookItem.progress / 100f).toFloat())
+                            .background(
+                                color = BookPinTheme.colors.buttonPrimary,
+                                shape = CircleShape,
+                            ),
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                Button(
+                    onClick = onAddBookmarkClick,
+                    modifier = Modifier.fillMaxWidth(),
+                    shape = RoundedCornerShape(12.dp),
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = BookPinTheme.colors.bgMuted,
+                    ),
+                    elevation = ButtonDefaults.buttonElevation(
+                        defaultElevation = 4.dp,
+                        pressedElevation = 6.dp,
+                    ),
+                ) {
+                    Text(
+                        text = stringResource(Res.string.leave_bookmark),
+                        style = BookPinTheme.typography.bodyMedium,
+                        color = BookPinTheme.colors.textPrimary,
+                    )
+                }
+            }
+        }
+    }
+}

--- a/feature/home/src/commonMain/kotlin/com/phase/bookpin/home/component/HomeTopBar.kt
+++ b/feature/home/src/commonMain/kotlin/com/phase/bookpin/home/component/HomeTopBar.kt
@@ -1,0 +1,59 @@
+package com.phase.bookpin.home.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import bookpin.home.generated.resources.Res
+import bookpin.home.generated.resources.app_name
+import bookpin.home.generated.resources.cd_settings
+import bookpin.home.generated.resources.setting
+import com.phase.bookpin.designsystem.BookPinTheme
+import org.jetbrains.compose.resources.painterResource
+import org.jetbrains.compose.resources.stringResource
+
+@Composable
+internal fun HomeTopBar(
+    onSettingsClick: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(20.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Text(
+            text = stringResource(Res.string.app_name),
+            style = BookPinTheme.typography.headlineLarge,
+            color = BookPinTheme.colors.textPrimary,
+        )
+
+        IconButton(
+            onClick = onSettingsClick,
+            modifier = Modifier
+                .size(36.dp)
+                .background(
+                    color = BookPinTheme.colors.bgSurface,
+                    shape = CircleShape,
+                ),
+        ) {
+            Icon(
+                painter = painterResource(Res.drawable.setting),
+                contentDescription = stringResource(Res.string.cd_settings),
+                modifier = Modifier.size(20.dp),
+                tint = BookPinTheme.colors.iconDefault,
+            )
+        }
+    }
+}

--- a/model/src/commonMain/kotlin/com/phase/bookpin/model/book/BookItem.kt
+++ b/model/src/commonMain/kotlin/com/phase/bookpin/model/book/BookItem.kt
@@ -1,0 +1,12 @@
+package com.phase.bookpin.model.book
+
+data class BookItem(
+    val id: Long,
+    val title: String,
+    val author: String,
+    val imageUrl: String,
+    val totalPage: Int,
+    val currentPage: Int,
+    val progress: Double,
+    val bookmarkCount: Int
+)


### PR DESCRIPTION
## 1. 📄 관련된 이슈 및 소개
- 관련 이슈: #34
- 소개: 홈 화면에 책장 목록 조회 API(`GET /api/v1/books`)를 연동하고, 기존 더미 데이터를 제거하여 실제 데이터를 표시하도록 구현했습니다. 홈 화면 UI 컴포넌트를 분리하고 이미지 로딩(Coil)을 적용했습니다.

## 2. 🔥 변경된 점
### Data Layer
- `BookItem` 비즈니스 모델 추가 (`model/`)
- `BookRepository` 인터페이스 및 `BookRepositoryImpl` 구현체 추가
- `BookRemoteDataSource` 인터페이스 및 `BookRemoteDataSourceImpl` 구현체 추가
- `BookItemResponse` DTO 추가
- `ClientModule` 수정 및 불필요한 `SessionExtensions` 제거
- Koin DI 모듈 등록 (`DataModule`, `DataRemoteModule`)

### Design System
- `BPLoadingScreen` 공통 로딩 컴포넌트 추가
- `BookCoverColorPicker` 책 표지 색상 유틸리티 추가
- Typography 일부 수정

### Feature/Home
- `HomeScreen` 대규모 리팩토링: 인라인 컴포넌트를 별도 파일로 분리
  - `HomeTopBar`, `BookAddButton`, `BookItemCard`, `CurrentlyReadingCard`
- `HomeViewModel`에 API 연동 로직 구현 (책장 목록 조회)
- `HomeState` 및 `HomeSideEffect` 수정
- Coil 의존성 추가로 책 표지 이미지 로딩 지원
- 로딩 상태 처리 (`BPLoadingScreen`) 적용
- 빈 책장 안내 문구 개선

### 기타
- `BookPinApp` Scaffold `containerColor` 설정
- `BookDetailScreen` BookId 타입 Long으로 변경
- Navigation Route BookId 타입 Long으로 변경

## 3. ✅ 필수 체크 사항
- [ ] 빌드 확인
- [ ] 테스트 확인
- [ ] 코드 리뷰 요청

## 4. 📸 작업물 사진 공유(선택)

## 5. 💡 알게된 혹은 궁금한 사항
- `HomeViewModel`에 테스트용 하드코딩 더미 데이터가 남아있습니다. API 연동 확인 후 제거가 필요합니다.