### PR TITLE
#29 : 책갈피 추가 화면 구현

### DIFF
--- a/compose-app/src/commonMain/kotlin/com/phase/bookpin/BookPinApp.kt
+++ b/compose-app/src/commonMain/kotlin/com/phase/bookpin/BookPinApp.kt
@@ -13,8 +13,10 @@ import androidx.savedstate.serialization.SavedStateConfiguration
 import com.phase.bookpin.common.extensions.collectSideEffect
 import com.phase.bookpin.common.snackbar.LocalSnackbarHost
 import com.phase.bookpin.designsystem.BookPinTheme
+import com.phase.bookpin.navigation.AddBookmarkRoute
 import com.phase.bookpin.navigation.BookDetailRoute
 import com.phase.bookpin.navigation.BookPinNavHost
+import com.phase.bookpin.navigation.BookmarkTypeSelectRoute
 import com.phase.bookpin.navigation.HomeRoute
 import com.phase.bookpin.navigation.SearchRoute
 import com.phase.bookpin.navigation.SettingsRoute
@@ -79,6 +81,12 @@ fun BookPinApp(
                     },
                     onNavigateToBookDetail = { bookId ->
                         backStack.add(BookDetailRoute(bookId))
+                    },
+                    onNavigateToBookmarkTypeSelect = { bookId ->
+                        backStack.add(BookmarkTypeSelectRoute(bookId))
+                    },
+                    onNavigateToAddBookmark = { bookId, type ->
+                        backStack.add(AddBookmarkRoute(bookId, type))
                     },
                     onNavigateToBookPreview = { route ->
                         backStack.add(route)

--- a/compose-app/src/commonMain/kotlin/com/phase/bookpin/navigation/BookPinNavHost.kt
+++ b/compose-app/src/commonMain/kotlin/com/phase/bookpin/navigation/BookPinNavHost.kt
@@ -5,8 +5,11 @@ import androidx.navigation3.runtime.NavBackStack
 import androidx.navigation3.runtime.NavKey
 import androidx.navigation3.runtime.entryProvider
 import androidx.navigation3.ui.NavDisplay
+import com.phase.bookpin.bookmark.add.AddBookmarkScreen
+import com.phase.bookpin.bookmark.add.BookmarkTypeSelectScreen
 import com.phase.bookpin.bookmark.detail.BookDetailScreen
 import com.phase.bookpin.home.HomeScreen
+import com.phase.bookpin.model.bookmark.BookmarkType
 import com.phase.bookpin.search.SearchScreen
 import com.phase.bookpin.search.preview.BookPreviewScreen
 import com.phase.bookpin.settings.SettingsScreen
@@ -18,6 +21,8 @@ fun BookPinNavHost(
     onNavigateToHome: () -> Unit,
     onNavigateToSearch: () -> Unit,
     onNavigateToBookDetail: (Long) -> Unit,
+    onNavigateToBookmarkTypeSelect: (Long) -> Unit,
+    onNavigateToAddBookmark: (Long, BookmarkType) -> Unit,
     onNavigateToBookPreview: (BookPreviewRoute) -> Unit,
     onNavigateToSettings: () -> Unit,
     onNavigateBack: () -> Unit,
@@ -74,6 +79,24 @@ fun BookPinNavHost(
             entry<BookDetailRoute> { route ->
                 BookDetailScreen(
                     bookId = route.bookId,
+                    onNavigateBack = onNavigateBack,
+                    onNavigateToAddBookmark = { onNavigateToBookmarkTypeSelect(route.bookId) },
+                )
+            }
+
+            entry<BookmarkTypeSelectRoute> { route ->
+                BookmarkTypeSelectScreen(
+                    onNavigateBack = onNavigateBack,
+                    onNavigateToAddBookmark = { type ->
+                        onNavigateToAddBookmark(route.bookId, type)
+                    },
+                )
+            }
+
+            entry<AddBookmarkRoute> { route ->
+                AddBookmarkScreen(
+                    bookId = route.bookId,
+                    bookmarkType = route.bookmarkType,
                     onNavigateBack = onNavigateBack,
                 )
             }

--- a/compose-app/src/commonMain/kotlin/com/phase/bookpin/navigation/BookPinNavHost.kt
+++ b/compose-app/src/commonMain/kotlin/com/phase/bookpin/navigation/BookPinNavHost.kt
@@ -5,7 +5,7 @@ import androidx.navigation3.runtime.NavBackStack
 import androidx.navigation3.runtime.NavKey
 import androidx.navigation3.runtime.entryProvider
 import androidx.navigation3.ui.NavDisplay
-import com.phase.bookpin.bookmark.BookDetailScreen
+import com.phase.bookpin.bookmark.detail.BookDetailScreen
 import com.phase.bookpin.home.HomeScreen
 import com.phase.bookpin.search.SearchScreen
 import com.phase.bookpin.search.preview.BookPreviewScreen

--- a/compose-app/src/commonMain/kotlin/com/phase/bookpin/navigation/Route.kt
+++ b/compose-app/src/commonMain/kotlin/com/phase/bookpin/navigation/Route.kt
@@ -1,6 +1,7 @@
 package com.phase.bookpin.navigation
 
 import androidx.navigation3.runtime.NavKey
+import com.phase.bookpin.model.bookmark.BookmarkType
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.modules.polymorphic
@@ -23,6 +24,17 @@ data class BookDetailRoute(
 data object SettingsRoute : NavKey
 
 @Serializable
+data class BookmarkTypeSelectRoute(
+    val bookId: Long,
+) : NavKey
+
+@Serializable
+data class AddBookmarkRoute(
+    val bookId: Long,
+    val bookmarkType: BookmarkType,
+) : NavKey
+
+@Serializable
 data class BookPreviewRoute(
     val title: String = "",
     val author: String = "",
@@ -37,6 +49,8 @@ val navSerializersModule = SerializersModule {
         subclass(HomeRoute::class, HomeRoute.serializer())
         subclass(SearchRoute::class, SearchRoute.serializer())
         subclass(BookDetailRoute::class, BookDetailRoute.serializer())
+        subclass(BookmarkTypeSelectRoute::class, BookmarkTypeSelectRoute.serializer())
+        subclass(AddBookmarkRoute::class, AddBookmarkRoute.serializer())
         subclass(SettingsRoute::class, SettingsRoute.serializer())
         subclass(BookPreviewRoute::class, BookPreviewRoute.serializer())
     }

--- a/designsystem/src/commonMain/kotlin/com/phase/bookpin/designsystem/component/BPOptionCard.kt
+++ b/designsystem/src/commonMain/kotlin/com/phase/bookpin/designsystem/component/BPOptionCard.kt
@@ -1,0 +1,65 @@
+package com.phase.bookpin.designsystem.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.unit.dp
+import com.phase.bookpin.designsystem.BookPinTheme
+
+@Composable
+fun BPOptionCard(
+    icon: Painter,
+    title: String,
+    subtitle: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val shape = RoundedCornerShape(16.dp)
+
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .shadow(elevation = 2.dp, shape = shape)
+            .background(color = BookPinTheme.colors.bgElevated, shape = shape)
+            .border(width = 1.dp, color = BookPinTheme.colors.bgSurface, shape = shape)
+            .clip(shape)
+            .clickable(onClick = onClick)
+            .padding(20.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(
+            painter = icon,
+            contentDescription = null,
+            modifier = Modifier.size(48.dp),
+            tint = BookPinTheme.colors.buttonPrimary,
+        )
+
+        Spacer(modifier = Modifier.width(16.dp))
+
+        Column {
+            Text(
+                text = title,
+                style = BookPinTheme.typography.bodyLarge,
+                color = BookPinTheme.colors.textPrimary,
+            )
+
+            Spacer(modifier = Modifier.height(4.dp))
+
+            Text(
+                text = subtitle,
+                style = BookPinTheme.typography.bodySmall,
+                color = BookPinTheme.colors.textSecondary,
+            )
+        }
+    }
+}

--- a/designsystem/src/commonMain/kotlin/com/phase/bookpin/designsystem/component/BPOptionCard.kt
+++ b/designsystem/src/commonMain/kotlin/com/phase/bookpin/designsystem/component/BPOptionCard.kt
@@ -29,10 +29,10 @@ fun BPOptionCard(
     Row(
         modifier = modifier
             .fillMaxWidth()
-            .shadow(elevation = 2.dp, shape = shape)
-            .background(color = BookPinTheme.colors.bgElevated, shape = shape)
-            .border(width = 1.dp, color = BookPinTheme.colors.bgSurface, shape = shape)
+            .shadow(elevation = 2.dp, shape = shape, clip = false)
             .clip(shape)
+            .background(color = BookPinTheme.colors.bgElevated)
+            .border(width = 1.dp, color = BookPinTheme.colors.borderDefault, shape = shape)
             .clickable(onClick = onClick)
             .padding(20.dp),
         verticalAlignment = Alignment.CenterVertically,

--- a/designsystem/src/commonMain/kotlin/com/phase/bookpin/designsystem/component/BPTextArea.kt
+++ b/designsystem/src/commonMain/kotlin/com/phase/bookpin/designsystem/component/BPTextArea.kt
@@ -1,0 +1,67 @@
+package com.phase.bookpin.designsystem.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.phase.bookpin.designsystem.BookPinTheme
+
+@Composable
+fun BPTextArea(
+    value: String,
+    onValueChange: (String) -> Unit,
+    modifier: Modifier = Modifier,
+    placeholder: String = "",
+    minHeight: Dp = 100.dp,
+    keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+) {
+    val shape = RoundedCornerShape(16.dp)
+
+    BasicTextField(
+        value = value,
+        onValueChange = onValueChange,
+        modifier = modifier
+            .fillMaxWidth()
+            .background(
+                color = BookPinTheme.colors.bgElevated,
+                shape = shape,
+            )
+            .border(
+                width = 1.846.dp,
+                color = BookPinTheme.colors.bgSurface,
+                shape = shape,
+            ),
+        textStyle = BookPinTheme.typography.bodyMedium.copy(
+            color = BookPinTheme.colors.textPrimary,
+        ),
+        cursorBrush = SolidColor(BookPinTheme.colors.buttonPrimary),
+        keyboardOptions = keyboardOptions,
+        decorationBox = { innerTextField ->
+            Box(
+                modifier = Modifier
+                    .defaultMinSize(minHeight = minHeight)
+                    .padding(16.dp),
+            ) {
+                if (value.isEmpty()) {
+                    Text(
+                        text = placeholder,
+                        style = BookPinTheme.typography.bodyMedium,
+                        color = BookPinTheme.colors.textPlaceholder,
+                    )
+                }
+                innerTextField()
+            }
+        },
+    )
+}

--- a/designsystem/src/commonMain/kotlin/com/phase/bookpin/designsystem/component/BPTextArea.kt
+++ b/designsystem/src/commonMain/kotlin/com/phase/bookpin/designsystem/component/BPTextArea.kt
@@ -38,8 +38,8 @@ fun BPTextArea(
                 shape = shape,
             )
             .border(
-                width = 1.846.dp,
-                color = BookPinTheme.colors.bgSurface,
+                width = 1.dp,
+                color = BookPinTheme.colors.borderDefault,
                 shape = shape,
             ),
         textStyle = BookPinTheme.typography.bodyMedium.copy(

--- a/designsystem/src/commonMain/kotlin/com/phase/bookpin/designsystem/component/BPTopBar.kt
+++ b/designsystem/src/commonMain/kotlin/com/phase/bookpin/designsystem/component/BPTopBar.kt
@@ -24,10 +24,12 @@ fun BPTopBar(
     onClose: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val borderColor = BookPinTheme.colors.borderSubtle
+
     Box(
         modifier = modifier
             .fillMaxWidth()
-            .drawBottomBorder()
+            .drawBottomBorder(borderColor)
             .padding(horizontal = 16.dp, vertical = 12.dp),
     ) {
         Text(
@@ -57,11 +59,11 @@ fun BPTopBar(
     }
 }
 
-private fun Modifier.drawBottomBorder(): Modifier = this.then(
+private fun Modifier.drawBottomBorder(color: Color): Modifier = this.then(
     Modifier.drawWithContent {
         drawContent()
         drawLine(
-            color = Color(0xFFF5EFE6),
+            color = color,
             start = Offset(0f, size.height),
             end = Offset(size.width, size.height),
             strokeWidth = 0.6.dp.toPx(),

--- a/designsystem/src/commonMain/kotlin/com/phase/bookpin/designsystem/component/BPTopBar.kt
+++ b/designsystem/src/commonMain/kotlin/com/phase/bookpin/designsystem/component/BPTopBar.kt
@@ -1,0 +1,70 @@
+package com.phase.bookpin.designsystem.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import bookpin.designsystem.generated.resources.Res
+import bookpin.designsystem.generated.resources.ic_close
+import com.phase.bookpin.designsystem.BookPinTheme
+import org.jetbrains.compose.resources.painterResource
+
+@Composable
+fun BPTopBar(
+    title: String,
+    onClose: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .drawBottomBorder()
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+    ) {
+        Text(
+            text = title,
+            style = BookPinTheme.typography.headlineSmall,
+            color = BookPinTheme.colors.textPrimary,
+            modifier = Modifier.align(Alignment.CenterStart),
+        )
+
+        IconButton(
+            onClick = onClose,
+            modifier = Modifier
+                .size(36.dp)
+                .background(
+                    color = BookPinTheme.colors.bgSurface,
+                    shape = CircleShape,
+                )
+                .align(Alignment.CenterEnd),
+        ) {
+            Icon(
+                painter = painterResource(Res.drawable.ic_close),
+                contentDescription = null,
+                modifier = Modifier.size(18.dp),
+                tint = BookPinTheme.colors.iconDefault,
+            )
+        }
+    }
+}
+
+private fun Modifier.drawBottomBorder(): Modifier = this.then(
+    Modifier.drawWithContent {
+        drawContent()
+        drawLine(
+            color = Color(0xFFF5EFE6),
+            start = Offset(0f, size.height),
+            end = Offset(size.width, size.height),
+            strokeWidth = 0.6.dp.toPx(),
+        )
+    },
+)

--- a/feature/bookmark/src/commonMain/composeResources/drawable/ic_camera.xml
+++ b/feature/bookmark/src/commonMain/composeResources/drawable/ic_camera.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#000000"
+        android:pathData="M12,12m-3.2,0a3.2,3.2 0,1 1,6.4 0a3.2,3.2 0,1 1,-6.4 0" />
+    <path
+        android:fillColor="#000000"
+        android:pathData="M9,2L7.17,4H4c-1.1,0 -2,0.9 -2,2v12c0,1.1 0.9,2 2,2h16c1.1,0 2,-0.9 2,-2V6c0,-1.1 -0.9,-2 -2,-2h-3.17L15,2H9zM12,17c-2.76,0 -5,-2.24 -5,-5s2.24,-5 5,-5 5,2.24 5,5 -2.24,5 -5,5z" />
+</vector>

--- a/feature/bookmark/src/commonMain/composeResources/drawable/ic_check.xml
+++ b/feature/bookmark/src/commonMain/composeResources/drawable/ic_check.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#000000"
+        android:pathData="M9,16.17L4.83,12l-1.42,1.41L9,19 21,7l-1.41,-1.41z" />
+</vector>

--- a/feature/bookmark/src/commonMain/composeResources/drawable/ic_edit.xml
+++ b/feature/bookmark/src/commonMain/composeResources/drawable/ic_edit.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#000000"
+        android:pathData="M3,17.25V21h3.75L17.81,9.94l-3.75,-3.75L3,17.25zM20.71,7.04c0.39,-0.39 0.39,-1.02 0,-1.41l-2.34,-2.34c-0.39,-0.39 -1.02,-0.39 -1.41,0l-1.83,1.83 3.75,3.75 1.83,-1.83z" />
+</vector>

--- a/feature/bookmark/src/commonMain/composeResources/drawable/ic_gallery.xml
+++ b/feature/bookmark/src/commonMain/composeResources/drawable/ic_gallery.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#000000"
+        android:pathData="M21,19V5c0,-1.1 -0.9,-2 -2,-2H5c-1.1,0 -2,0.9 -2,2v14c0,1.1 0.9,2 2,2h14c1.1,0 2,-0.9 2,-2zM8.5,13.5l2.5,3.01L14.5,12l4.5,6H5l3.5,-4.5z" />
+</vector>

--- a/feature/bookmark/src/commonMain/composeResources/values/strings.xml
+++ b/feature/bookmark/src/commonMain/composeResources/values/strings.xml
@@ -7,6 +7,23 @@
     <string name="tab_photo">사진</string>
     <string name="page_format">p.%1$d</string>
 
+    <!-- Add Bookmark -->
+    <string name="bookmark_add_title">책갈피 추가</string>
+    <string name="bookmark_type_question">어떤 방식으로 책갈피를 추가할까요?</string>
+    <string name="bookmark_type_camera">사진 촬영</string>
+    <string name="bookmark_type_camera_desc">OCR로 텍스트 추출</string>
+    <string name="bookmark_type_gallery">갤러리에서 선택</string>
+    <string name="bookmark_type_gallery_desc">기존 사진 불러오기</string>
+    <string name="bookmark_type_text">직접 입력하기</string>
+    <string name="bookmark_extracted_text">추출된 텍스트</string>
+    <string name="bookmark_content_label">책갈피 내용</string>
+    <string name="bookmark_extracted_text_placeholder">책갈피 내용을 입력하거나 수정하세요...</string>
+    <string name="bookmark_page_number">페이지 번호</string>
+    <string name="bookmark_page_placeholder">선택사항</string>
+    <string name="bookmark_personal_memo">개인 메모</string>
+    <string name="bookmark_memo_placeholder">생각을 기록하세요 (선택사항)</string>
+    <string name="bookmark_save">책갈피 저장</string>
+
     <!-- Content Descriptions -->
     <string name="cd_back">뒤로가기</string>
     <string name="cd_add_bookmark">북마크 추가</string>

--- a/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/add/AddBookmarkScreen.kt
+++ b/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/add/AddBookmarkScreen.kt
@@ -1,0 +1,183 @@
+package com.phase.bookpin.bookmark.add
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import bookpin.bookmark.generated.resources.*
+import com.phase.bookpin.common.extensions.collectSideEffect
+import com.phase.bookpin.common.snackbar.LocalSnackbarHost
+import com.phase.bookpin.designsystem.BookPinTheme
+import com.phase.bookpin.designsystem.component.BPTextArea
+import com.phase.bookpin.designsystem.component.BPTopBar
+import com.phase.bookpin.model.bookmark.BookmarkType
+import org.jetbrains.compose.resources.painterResource
+import org.jetbrains.compose.resources.stringResource
+import org.koin.compose.viewmodel.koinViewModel
+
+@Composable
+fun AddBookmarkScreen(
+    bookId: Long,
+    bookmarkType: BookmarkType,
+    onNavigateBack: () -> Unit,
+) {
+    val viewModel: AddBookmarkViewModel = koinViewModel()
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    val snackbarHost = LocalSnackbarHost.current
+
+    LaunchedEffect(bookmarkType) {
+        viewModel.initBookmarkType(bookmarkType)
+    }
+
+    viewModel.sideEffect.collectSideEffect {
+        when (it) {
+            is AddBookmarkSideEffect.ShowSnackbar -> {
+                snackbarHost.showSnackbar(it.message)
+            }
+            AddBookmarkSideEffect.NavigateBack -> onNavigateBack()
+            AddBookmarkSideEffect.BookmarkSaved -> onNavigateBack()
+        }
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(BookPinTheme.colors.bgCanvas),
+    ) {
+        BPTopBar(
+            title = stringResource(Res.string.bookmark_add_title),
+            onClose = viewModel::onCloseClick,
+        )
+
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 24.dp)
+                .padding(top = 24.dp, bottom = 32.dp),
+        ) {
+            if (state.bookmarkType != BookmarkType.TEXT) {
+                PhotoPlaceholder()
+                Spacer(modifier = Modifier.height(24.dp))
+            }
+
+            Text(
+                text = if (state.bookmarkType != BookmarkType.TEXT) {
+                    stringResource(Res.string.bookmark_extracted_text)
+                } else {
+                    stringResource(Res.string.bookmark_content_label)
+                },
+                style = BookPinTheme.typography.titleSmall,
+                color = BookPinTheme.colors.textPrimary,
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            BPTextArea(
+                value = state.extractedText,
+                onValueChange = viewModel::onExtractedTextChanged,
+                placeholder = stringResource(Res.string.bookmark_extracted_text_placeholder),
+                minHeight = 172.dp,
+            )
+
+            Spacer(modifier = Modifier.height(20.dp))
+
+            Text(
+                text = stringResource(Res.string.bookmark_page_number),
+                style = BookPinTheme.typography.titleSmall,
+                color = BookPinTheme.colors.textPrimary,
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            BPTextArea(
+                value = state.pageNumber,
+                onValueChange = viewModel::onPageNumberChanged,
+                placeholder = stringResource(Res.string.bookmark_page_placeholder),
+                minHeight = 48.dp,
+                modifier = Modifier.fillMaxWidth(0.5f),
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+            )
+
+            Spacer(modifier = Modifier.height(20.dp))
+
+            Text(
+                text = stringResource(Res.string.bookmark_personal_memo),
+                style = BookPinTheme.typography.titleSmall,
+                color = BookPinTheme.colors.textPrimary,
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            BPTextArea(
+                value = state.personalMemo,
+                onValueChange = viewModel::onPersonalMemoChanged,
+                placeholder = stringResource(Res.string.bookmark_memo_placeholder),
+                minHeight = 100.dp,
+            )
+
+            Spacer(modifier = Modifier.height(32.dp))
+
+            Button(
+                onClick = viewModel::onSaveBookmark,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(52.dp),
+                shape = RoundedCornerShape(26.dp),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = BookPinTheme.colors.buttonPrimary,
+                    contentColor = BookPinTheme.colors.textOnAccent,
+                ),
+            ) {
+                Icon(
+                    painter = painterResource(Res.drawable.ic_check),
+                    contentDescription = null,
+                    modifier = Modifier.size(20.dp),
+                    tint = BookPinTheme.colors.textOnAccent,
+                )
+
+                Spacer(modifier = Modifier.width(8.dp))
+
+                Text(
+                    text = stringResource(Res.string.bookmark_save),
+                    style = BookPinTheme.typography.titleMedium,
+                    color = BookPinTheme.colors.textOnAccent,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun PhotoPlaceholder() {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(200.dp)
+            .clip(RoundedCornerShape(16.dp))
+            .background(BookPinTheme.colors.bgSurface),
+        contentAlignment = Alignment.Center,
+    ) {
+        Icon(
+            painter = painterResource(Res.drawable.ic_photo),
+            contentDescription = null,
+            modifier = Modifier.size(48.dp),
+            tint = BookPinTheme.colors.iconDefault,
+        )
+    }
+}

--- a/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/add/AddBookmarkSideEffect.kt
+++ b/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/add/AddBookmarkSideEffect.kt
@@ -1,0 +1,9 @@
+package com.phase.bookpin.bookmark.add
+
+sealed interface AddBookmarkSideEffect {
+    data class ShowSnackbar(
+        val message: String,
+    ) : AddBookmarkSideEffect
+    data object NavigateBack : AddBookmarkSideEffect
+    data object BookmarkSaved : AddBookmarkSideEffect
+}

--- a/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/add/AddBookmarkState.kt
+++ b/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/add/AddBookmarkState.kt
@@ -1,0 +1,12 @@
+package com.phase.bookpin.bookmark.add
+
+import com.phase.bookpin.model.bookmark.BookmarkType
+
+data class AddBookmarkState(
+    val bookmarkType: BookmarkType = BookmarkType.TEXT,
+    val photoUri: String? = null,
+    val extractedText: String = "",
+    val pageNumber: String = "",
+    val personalMemo: String = "",
+    val isLoading: Boolean = false,
+)

--- a/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/add/AddBookmarkViewModel.kt
+++ b/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/add/AddBookmarkViewModel.kt
@@ -1,0 +1,33 @@
+package com.phase.bookpin.bookmark.add
+
+import com.phase.bookpin.common.BaseViewModel
+import com.phase.bookpin.model.bookmark.BookmarkType
+
+class AddBookmarkViewModel : BaseViewModel<AddBookmarkState, AddBookmarkSideEffect>() {
+    override fun createInitialState(): AddBookmarkState = AddBookmarkState()
+
+    fun initBookmarkType(type: BookmarkType) {
+        reduce { copy(bookmarkType = type) }
+    }
+
+    fun onExtractedTextChanged(text: String) {
+        reduce { copy(extractedText = text) }
+    }
+
+    fun onPageNumberChanged(page: String) {
+        reduce { copy(pageNumber = page) }
+    }
+
+    fun onPersonalMemoChanged(memo: String) {
+        reduce { copy(personalMemo = memo) }
+    }
+
+    fun onSaveBookmark() {
+        // TODO: API 연동 후 구현
+        postSideEffect(AddBookmarkSideEffect.BookmarkSaved)
+    }
+
+    fun onCloseClick() {
+        postSideEffect(AddBookmarkSideEffect.NavigateBack)
+    }
+}

--- a/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/add/BookmarkTypeSelectScreen.kt
+++ b/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/add/BookmarkTypeSelectScreen.kt
@@ -1,0 +1,86 @@
+package com.phase.bookpin.bookmark.add
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import bookpin.bookmark.generated.resources.*
+import com.phase.bookpin.designsystem.BookPinTheme
+import com.phase.bookpin.designsystem.component.BPOptionCard
+import com.phase.bookpin.designsystem.component.BPTopBar
+import com.phase.bookpin.model.bookmark.BookmarkType
+import org.jetbrains.compose.resources.painterResource
+import org.jetbrains.compose.resources.stringResource
+
+@Composable
+fun BookmarkTypeSelectScreen(
+    onNavigateBack: () -> Unit,
+    onNavigateToAddBookmark: (BookmarkType) -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(BookPinTheme.colors.bgCanvas),
+    ) {
+        BPTopBar(
+            title = stringResource(Res.string.bookmark_add_title),
+            onClose = onNavigateBack,
+        )
+
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 24.dp)
+                .padding(top = 32.dp),
+        ) {
+            Text(
+                text = stringResource(Res.string.bookmark_type_question),
+                style = BookPinTheme.typography.bodyLarge,
+                color = BookPinTheme.colors.textSecondary,
+            )
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            BPOptionCard(
+                icon = painterResource(Res.drawable.ic_camera),
+                title = stringResource(Res.string.bookmark_type_camera),
+                subtitle = stringResource(Res.string.bookmark_type_camera_desc),
+                onClick = { onNavigateToAddBookmark(BookmarkType.PHOTO_CAMERA) },
+            )
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            BPOptionCard(
+                icon = painterResource(Res.drawable.ic_gallery),
+                title = stringResource(Res.string.bookmark_type_gallery),
+                subtitle = stringResource(Res.string.bookmark_type_gallery_desc),
+                onClick = { onNavigateToAddBookmark(BookmarkType.PHOTO_GALLERY) },
+            )
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            Button(
+                onClick = { onNavigateToAddBookmark(BookmarkType.TEXT) },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(52.dp),
+                shape = RoundedCornerShape(16.dp),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = BookPinTheme.colors.buttonPrimary,
+                    contentColor = BookPinTheme.colors.textOnAccent,
+                ),
+            ) {
+                Text(
+                    text = stringResource(Res.string.bookmark_type_text),
+                    style = BookPinTheme.typography.titleMedium,
+                    color = BookPinTheme.colors.textOnAccent,
+                )
+            }
+        }
+    }
+}

--- a/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/add/BookmarkTypeSelectScreen.kt
+++ b/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/add/BookmarkTypeSelectScreen.kt
@@ -10,8 +10,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import bookpin.bookmark.generated.resources.*
+import com.phase.bookpin.bookmark.component.BookmarkTypeOptionCard
 import com.phase.bookpin.designsystem.BookPinTheme
-import com.phase.bookpin.designsystem.component.BPOptionCard
 import com.phase.bookpin.designsystem.component.BPTopBar
 import com.phase.bookpin.model.bookmark.BookmarkType
 import org.jetbrains.compose.resources.painterResource
@@ -46,7 +46,7 @@ fun BookmarkTypeSelectScreen(
 
             Spacer(modifier = Modifier.height(24.dp))
 
-            BPOptionCard(
+            BookmarkTypeOptionCard(
                 icon = painterResource(Res.drawable.ic_camera),
                 title = stringResource(Res.string.bookmark_type_camera),
                 subtitle = stringResource(Res.string.bookmark_type_camera_desc),
@@ -55,7 +55,7 @@ fun BookmarkTypeSelectScreen(
 
             Spacer(modifier = Modifier.height(12.dp))
 
-            BPOptionCard(
+            BookmarkTypeOptionCard(
                 icon = painterResource(Res.drawable.ic_gallery),
                 title = stringResource(Res.string.bookmark_type_gallery),
                 subtitle = stringResource(Res.string.bookmark_type_gallery_desc),

--- a/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/component/BookmarkTypeOptionCard.kt
+++ b/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/component/BookmarkTypeOptionCard.kt
@@ -1,4 +1,4 @@
-package com.phase.bookpin.designsystem.component
+package com.phase.bookpin.bookmark.component
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -17,7 +17,7 @@ import androidx.compose.ui.unit.dp
 import com.phase.bookpin.designsystem.BookPinTheme
 
 @Composable
-fun BPOptionCard(
+fun BookmarkTypeOptionCard(
     icon: Painter,
     title: String,
     subtitle: String,

--- a/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/detail/BookDetailScreen.kt
+++ b/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/detail/BookDetailScreen.kt
@@ -38,6 +38,7 @@ import org.koin.compose.viewmodel.koinViewModel
 fun BookDetailScreen(
     bookId: Long,
     onNavigateBack: () -> Unit = {},
+    onNavigateToAddBookmark: () -> Unit = {},
 ) {
     val viewModel: BookDetailViewModel = koinViewModel()
     val state by viewModel.uiState.collectAsStateWithLifecycle()
@@ -49,9 +50,7 @@ fun BookDetailScreen(
                 snackbarHost.showSnackbar(it.message)
             }
             BookDetailSideEffect.NavigateBack -> onNavigateBack()
-            BookDetailSideEffect.NavigateToAddBookmark -> {
-                // TODO: Navigate to add bookmark screen
-            }
+            BookDetailSideEffect.NavigateToAddBookmark -> onNavigateToAddBookmark()
         }
     }
 

--- a/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/detail/BookDetailScreen.kt
+++ b/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/detail/BookDetailScreen.kt
@@ -1,4 +1,4 @@
-package com.phase.bookpin.bookmark
+package com.phase.bookpin.bookmark.detail
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border

--- a/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/detail/BookDetailSideEffect.kt
+++ b/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/detail/BookDetailSideEffect.kt
@@ -1,4 +1,4 @@
-package com.phase.bookpin.bookmark
+package com.phase.bookpin.bookmark.detail
 
 sealed interface BookDetailSideEffect {
     data class ShowSnackbar(

--- a/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/detail/BookDetailState.kt
+++ b/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/detail/BookDetailState.kt
@@ -1,4 +1,4 @@
-package com.phase.bookpin.bookmark
+package com.phase.bookpin.bookmark.detail
 
 data class BookDetailState(
     val book: BookDetail = BookDetail(),

--- a/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/detail/BookDetailViewModel.kt
+++ b/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/detail/BookDetailViewModel.kt
@@ -1,4 +1,4 @@
-package com.phase.bookpin.bookmark
+package com.phase.bookpin.bookmark.detail
 
 import com.phase.bookpin.common.BaseViewModel
 

--- a/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/di/BookDetailModule.kt
+++ b/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/di/BookDetailModule.kt
@@ -1,6 +1,6 @@
 package com.phase.bookpin.bookmark.di
 
-import com.phase.bookpin.bookmark.BookDetailViewModel
+import com.phase.bookpin.bookmark.detail.BookDetailViewModel
 import org.koin.core.module.dsl.viewModelOf
 import org.koin.dsl.module
 

--- a/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/di/BookDetailModule.kt
+++ b/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/di/BookDetailModule.kt
@@ -1,9 +1,11 @@
 package com.phase.bookpin.bookmark.di
 
+import com.phase.bookpin.bookmark.add.AddBookmarkViewModel
 import com.phase.bookpin.bookmark.detail.BookDetailViewModel
 import org.koin.core.module.dsl.viewModelOf
 import org.koin.dsl.module
 
 val bookDetailModule = module {
     viewModelOf(::BookDetailViewModel)
+    viewModelOf(::AddBookmarkViewModel)
 }

--- a/model/src/commonMain/kotlin/com/phase/bookpin/model/bookmark/BookmarkType.kt
+++ b/model/src/commonMain/kotlin/com/phase/bookpin/model/bookmark/BookmarkType.kt
@@ -1,0 +1,7 @@
+package com.phase.bookpin.model.bookmark
+
+enum class BookmarkType {
+    PHOTO_CAMERA,
+    PHOTO_GALLERY,
+    TEXT,
+}


### PR DESCRIPTION
## Summary
- **종류 선택 화면**: 사진 촬영 / 갤러리에서 선택 / 직접 입력하기 3가지 옵션 제공
- **책갈피 작성 화면**: 사진/텍스트 모드 통합 화면 (추출된 텍스트, 페이지 번호, 개인 메모 입력)
- **디자인 시스템 컴포넌트**: BPTopBar, BPTextArea, BPOptionCard 공통 컴포넌트 추가
- **BookmarkType enum**: model 모듈에 분리하여 Navigation Route에서 타입 안전하게 전달
- **Navigation 연결**: BookDetailScreen FAB → 종류 선택 → 작성 화면 flow 완성

## 제외 사항
- 사진 촬영/갤러리 선택 기능 미구현 (UI placeholder만 구성)
- 책갈피 저장 API 연동 미구현 (ViewModel에 TODO)

## Test plan
- [ ] BookDetailScreen에서 FAB(+) 클릭 → 종류 선택 화면 이동 확인
- [ ] 사진 촬영 / 갤러리 선택 클릭 → AddBookmarkScreen (사진 모드) 이동 확인
- [ ] 직접 입력하기 클릭 → AddBookmarkScreen (텍스트 모드) 이동 확인
- [ ] 텍스트 모드에서 사진 영역 숨김 확인
- [ ] 텍스트 입력 필드 동작 확인 (추출된 텍스트, 페이지 번호, 개인 메모)
- [ ] X 버튼으로 뒤로가기 확인
- [ ] `./gradlew assembleDebug` 빌드 성공 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)