### PR TITLE
#45 : BookDetailScreen 서버 API 연동

### DIFF
--- a/core/data-api/src/commonMain/kotlin/com/phase/bookpin/data/api/book/BookDetailResponse.kt
+++ b/core/data-api/src/commonMain/kotlin/com/phase/bookpin/data/api/book/BookDetailResponse.kt
@@ -1,0 +1,28 @@
+package com.phase.bookpin.data.api.book
+
+import com.phase.bookpin.model.book.BookDetail
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class BookDetailResponse(
+    val id: Long,
+    val title: String = "",
+    val author: String = "",
+    val imageUrl: String = "",
+    val totalPage: Int = 0,
+    val currentPage: Int = 0,
+    val progress: Double = 0.0,
+    val isCompleted: Boolean = false,
+    val createdAt: String = "",
+) {
+    fun toBookDetail(): BookDetail = BookDetail(
+        id = id,
+        title = title,
+        author = author,
+        imageUrl = imageUrl,
+        totalPage = totalPage,
+        currentPage = currentPage,
+        progress = progress,
+        isCompleted = isCompleted,
+    )
+}

--- a/core/data-api/src/commonMain/kotlin/com/phase/bookpin/data/api/book/BookRemoteDataSource.kt
+++ b/core/data-api/src/commonMain/kotlin/com/phase/bookpin/data/api/book/BookRemoteDataSource.kt
@@ -2,4 +2,7 @@ package com.phase.bookpin.data.api.book
 
 interface BookRemoteDataSource {
     suspend fun getBookItems(): Result<List<BookItemResponse>>
+    suspend fun getBookDetail(bookId: Long): Result<BookDetailResponse>
+    suspend fun getTextBookmarks(bookId: Long): Result<List<BookmarkResponse>>
+    suspend fun getPhotoBookmarks(bookId: Long): Result<List<BookmarkResponse>>
 }

--- a/core/data-api/src/commonMain/kotlin/com/phase/bookpin/data/api/book/BookmarkResponse.kt
+++ b/core/data-api/src/commonMain/kotlin/com/phase/bookpin/data/api/book/BookmarkResponse.kt
@@ -1,0 +1,24 @@
+package com.phase.bookpin.data.api.book
+
+import com.phase.bookpin.model.book.Bookmark
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class BookmarkResponse(
+    val id: Long,
+    val bookId: Long,
+    val pageNumber: Int = 0,
+    val extractedText: String = "",
+    val note: String = "",
+    val imageUrl: String = "",
+    val createdAt: String = "",
+) {
+    fun toBookmark(): Bookmark = Bookmark(
+        id = id,
+        bookId = bookId,
+        pageNumber = pageNumber,
+        extractedText = extractedText,
+        note = note,
+        imageUrl = imageUrl,
+    )
+}

--- a/core/data-remote/src/commonMain/kotlin/com/phase/bookpin/data/remote/book/BookRemoteDataSourceImpl.kt
+++ b/core/data-remote/src/commonMain/kotlin/com/phase/bookpin/data/remote/book/BookRemoteDataSourceImpl.kt
@@ -1,7 +1,9 @@
 package com.phase.bookpin.data.remote.book
 
+import com.phase.bookpin.data.api.book.BookDetailResponse
 import com.phase.bookpin.data.api.book.BookItemResponse
 import com.phase.bookpin.data.api.book.BookRemoteDataSource
+import com.phase.bookpin.data.api.book.BookmarkResponse
 import com.phase.bookpin.data.remote.client.safeRequest
 import io.ktor.client.HttpClient
 import io.ktor.http.HttpMethod
@@ -9,12 +11,36 @@ import io.ktor.http.path
 
 class BookRemoteDataSourceImpl(
     private val httpClient: HttpClient,
-): BookRemoteDataSource {
+) : BookRemoteDataSource {
     override suspend fun getBookItems(): Result<List<BookItemResponse>> =
         httpClient.safeRequest {
             url {
                 method = HttpMethod.Get
                 path("api/v1/books")
+            }
+        }
+
+    override suspend fun getBookDetail(bookId: Long): Result<BookDetailResponse> =
+        httpClient.safeRequest {
+            url {
+                method = HttpMethod.Get
+                path("api/v1/books/$bookId")
+            }
+        }
+
+    override suspend fun getTextBookmarks(bookId: Long): Result<List<BookmarkResponse>> =
+        httpClient.safeRequest {
+            url {
+                method = HttpMethod.Get
+                path("api/v1/books/$bookId/bookmarks/text")
+            }
+        }
+
+    override suspend fun getPhotoBookmarks(bookId: Long): Result<List<BookmarkResponse>> =
+        httpClient.safeRequest {
+            url {
+                method = HttpMethod.Get
+                path("api/v1/books/$bookId/bookmarks/photo")
             }
         }
 }

--- a/core/data-remote/src/commonMain/kotlin/com/phase/bookpin/data/remote/client/RemoteException.kt
+++ b/core/data-remote/src/commonMain/kotlin/com/phase/bookpin/data/remote/client/RemoteException.kt
@@ -10,7 +10,7 @@ data class RemoteException(
     val status: Int = -1,
     val detail: String = "알 수 없는 오류가 발생하였습니다.",
     val instance: String = "",
-) : Exception() {
+) : Exception(detail) {
     enum class NetworkExceptionViewType {
         TOAST
     }

--- a/core/data/src/commonMain/kotlin/com/phase/bookpin/data/book/BookRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/com/phase/bookpin/data/book/BookRepositoryImpl.kt
@@ -2,16 +2,32 @@ package com.phase.bookpin.data.book
 
 import com.phase.bookpin.data.api.book.BookRemoteDataSource
 import com.phase.bookpin.domain.book.BookRepository
+import com.phase.bookpin.model.book.BookDetail
 import com.phase.bookpin.model.book.BookItem
+import com.phase.bookpin.model.book.Bookmark
 
 class BookRepositoryImpl(
     private val dataSource: BookRemoteDataSource,
-): BookRepository {
+) : BookRepository {
     override suspend fun getBookItems(): Result<List<BookItem>> {
         return dataSource.getBookItems().mapCatching { responses ->
-            responses.map {
-                it.toBookItem()
-            }
+            responses.map { it.toBookItem() }
+        }
+    }
+
+    override suspend fun getBookDetail(bookId: Long): Result<BookDetail> {
+        return dataSource.getBookDetail(bookId).mapCatching { it.toBookDetail() }
+    }
+
+    override suspend fun getTextBookmarks(bookId: Long): Result<List<Bookmark>> {
+        return dataSource.getTextBookmarks(bookId).mapCatching { responses ->
+            responses.map { it.toBookmark() }
+        }
+    }
+
+    override suspend fun getPhotoBookmarks(bookId: Long): Result<List<Bookmark>> {
+        return dataSource.getPhotoBookmarks(bookId).mapCatching { responses ->
+            responses.map { it.toBookmark() }
         }
     }
 }

--- a/domain/src/commonMain/kotlin/com/phase/bookpin/domain/book/BookRepository.kt
+++ b/domain/src/commonMain/kotlin/com/phase/bookpin/domain/book/BookRepository.kt
@@ -1,7 +1,12 @@
 package com.phase.bookpin.domain.book
 
+import com.phase.bookpin.model.book.BookDetail
 import com.phase.bookpin.model.book.BookItem
+import com.phase.bookpin.model.book.Bookmark
 
 interface BookRepository {
     suspend fun getBookItems(): Result<List<BookItem>>
+    suspend fun getBookDetail(bookId: Long): Result<BookDetail>
+    suspend fun getTextBookmarks(bookId: Long): Result<List<Bookmark>>
+    suspend fun getPhotoBookmarks(bookId: Long): Result<List<Bookmark>>
 }

--- a/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/BookDetailScreen.kt
+++ b/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/BookDetailScreen.kt
@@ -8,12 +8,14 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -30,6 +32,8 @@ import coil3.compose.AsyncImage
 import com.phase.bookpin.common.extensions.collectSideEffect
 import com.phase.bookpin.common.snackbar.LocalSnackbarHost
 import com.phase.bookpin.designsystem.BookPinTheme
+import com.phase.bookpin.model.book.BookDetail
+import com.phase.bookpin.model.book.Bookmark
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.viewmodel.koinViewModel
@@ -42,6 +46,10 @@ fun BookDetailScreen(
     val viewModel: BookDetailViewModel = koinViewModel()
     val state by viewModel.uiState.collectAsStateWithLifecycle()
     val snackbarHost = LocalSnackbarHost.current
+
+    LaunchedEffect(bookId) {
+        viewModel.init(bookId)
+    }
 
     viewModel.sideEffect.collectSideEffect {
         when (it) {
@@ -72,59 +80,69 @@ fun BookDetailScreen(
             }
         },
     ) { paddingValues ->
-        LazyColumn(
-            modifier = Modifier
-                .fillMaxSize()
-                .background(BookPinTheme.colors.bgCanvas),
-            contentPadding = PaddingValues(bottom = paddingValues.calculateBottomPadding() + 80.dp),
-        ) {
-            item {
-                BookDetailHeader(
-                    book = state.book,
-                    onBackClick = viewModel::onBackClick,
+        if (state.isLoading) {
+            Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center,
+            ) {
+                CircularProgressIndicator(
+                    color = BookPinTheme.colors.buttonPrimary,
                 )
             }
-
-            item {
-                BookDetailStats(
-                    currentPage = state.book.currentPage,
-                    totalPages = state.book.totalPages,
-                    progressPercent = state.book.progressPercent,
-                    onMarkAsCompleteClick = viewModel::onMarkAsCompleteClick,
-                )
-            }
-
-            item {
-                BookDetailTabs(
-                    selectedTab = state.selectedTab,
-                    textCount = viewModel.textBookmarkCount,
-                    photoCount = viewModel.photoBookmarkCount,
-                    onTabSelected = viewModel::onTabSelected,
-                )
-            }
-
-            val filteredBookmarks = state.bookmarks.filter { it.type == state.selectedTab }
-            if (state.selectedTab == BookmarkTab.TEXT) {
-                items(filteredBookmarks, key = { it.id }) { bookmark ->
-                    BookmarkItem(bookmark = bookmark)
+        } else {
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(BookPinTheme.colors.bgCanvas),
+                contentPadding = PaddingValues(bottom = paddingValues.calculateBottomPadding() + 80.dp),
+            ) {
+                item {
+                    BookDetailHeader(
+                        book = state.book,
+                        onBackClick = viewModel::onBackClick,
+                    )
                 }
-            } else {
-                items(filteredBookmarks.chunked(2)) { rowItems ->
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = 24.dp)
-                            .padding(top = 16.dp),
-                        horizontalArrangement = Arrangement.spacedBy(12.dp),
-                    ) {
-                        rowItems.forEach { bookmark ->
-                            PhotoBookmarkItem(
-                                bookmark = bookmark,
-                                modifier = Modifier.weight(1f),
-                            )
-                        }
-                        if (rowItems.size == 1) {
-                            Spacer(modifier = Modifier.weight(1f))
+
+                item {
+                    BookDetailStats(
+                        currentPage = state.book.currentPage,
+                        totalPages = state.book.totalPage,
+                        progressPercent = (state.book.progress * 100).toInt(),
+                        onMarkAsCompleteClick = viewModel::onMarkAsCompleteClick,
+                    )
+                }
+
+                item {
+                    BookDetailTabs(
+                        selectedTab = state.selectedTab,
+                        textCount = state.textBookmarks.size,
+                        photoCount = state.photoBookmarks.size,
+                        onTabSelected = viewModel::onTabSelected,
+                    )
+                }
+
+                if (state.selectedTab == BookmarkTab.TEXT) {
+                    items(state.textBookmarks, key = { it.id }) { bookmark ->
+                        TextBookmarkItem(bookmark = bookmark)
+                    }
+                } else {
+                    items(state.photoBookmarks.chunked(2)) { rowItems ->
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 24.dp)
+                                .padding(top = 16.dp),
+                            horizontalArrangement = Arrangement.spacedBy(12.dp),
+                        ) {
+                            rowItems.forEach { bookmark ->
+                                PhotoBookmarkItem(
+                                    bookmark = bookmark,
+                                    modifier = Modifier.weight(1f),
+                                )
+                            }
+                            if (rowItems.size == 1) {
+                                Spacer(modifier = Modifier.weight(1f))
+                            }
                         }
                     }
                 }
@@ -355,7 +373,7 @@ private fun TabItem(
 }
 
 @Composable
-private fun BookmarkItem(
+private fun TextBookmarkItem(
     bookmark: Bookmark,
 ) {
     Column(
@@ -380,16 +398,16 @@ private fun BookmarkItem(
         Spacer(modifier = Modifier.height(8.dp))
 
         Text(
-            text = bookmark.quote,
+            text = bookmark.extractedText,
             style = BookPinTheme.typography.bodyLarge,
             color = BookPinTheme.colors.textPrimary,
         )
 
-        if (bookmark.memo.isNotEmpty()) {
+        if (bookmark.note.isNotEmpty()) {
             Spacer(modifier = Modifier.height(8.dp))
 
             Text(
-                text = bookmark.memo,
+                text = bookmark.note,
                 style = BookPinTheme.typography.bodyMedium.copy(
                     fontStyle = FontStyle.Italic,
                 ),
@@ -425,7 +443,7 @@ private fun PhotoBookmarkItem(
                 .background(BookPinTheme.colors.bgSurface),
             contentAlignment = Alignment.Center,
         ) {
-            if (bookmark.photoUrl.isNullOrEmpty()) {
+            if (bookmark.imageUrl.isEmpty()) {
                 Icon(
                     painter = painterResource(Res.drawable.ic_photo),
                     contentDescription = null,
@@ -434,7 +452,7 @@ private fun PhotoBookmarkItem(
                 )
             } else {
                 AsyncImage(
-                    model = bookmark.photoUrl,
+                    model = bookmark.imageUrl,
                     contentDescription = null,
                     modifier = Modifier.fillMaxSize(),
                     contentScale = ContentScale.Crop,
@@ -454,18 +472,18 @@ private fun PhotoBookmarkItem(
             Spacer(modifier = Modifier.height(4.dp))
 
             Text(
-                text = bookmark.quote,
+                text = bookmark.extractedText,
                 style = BookPinTheme.typography.bodyMedium,
                 color = BookPinTheme.colors.textPrimary,
                 maxLines = 3,
                 overflow = TextOverflow.Ellipsis,
             )
 
-            if (bookmark.memo.isNotEmpty()) {
+            if (bookmark.note.isNotEmpty()) {
                 Spacer(modifier = Modifier.height(4.dp))
 
                 Text(
-                    text = bookmark.memo,
+                    text = bookmark.note,
                     style = BookPinTheme.typography.labelSmall.copy(
                         fontStyle = FontStyle.Italic,
                     ),

--- a/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/BookDetailState.kt
+++ b/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/BookDetailState.kt
@@ -1,32 +1,14 @@
 package com.phase.bookpin.bookmark
 
+import com.phase.bookpin.model.book.BookDetail
+import com.phase.bookpin.model.book.Bookmark
+
 data class BookDetailState(
     val book: BookDetail = BookDetail(),
-    val bookmarks: List<Bookmark> = emptyList(),
+    val textBookmarks: List<Bookmark> = emptyList(),
+    val photoBookmarks: List<Bookmark> = emptyList(),
     val selectedTab: BookmarkTab = BookmarkTab.TEXT,
-)
-
-data class BookDetail(
-    val id: String = "",
-    val title: String = "",
-    val author: String = "",
-    val coverImageUrl: String = "",
-    val currentPage: Int = 0,
-    val totalPages: Int = 0,
-    val bookmarkCount: Int = 0,
-    val isCompleted: Boolean = false,
-) {
-    val progressPercent: Int
-        get() = if (totalPages > 0) (currentPage * 100 / totalPages) else 0
-}
-
-data class Bookmark(
-    val id: String = "",
-    val pageNumber: Int = 0,
-    val quote: String = "",
-    val memo: String = "",
-    val type: BookmarkTab = BookmarkTab.TEXT,
-    val photoUrl: String? = null,
+    val isLoading: Boolean = false,
 )
 
 enum class BookmarkTab {

--- a/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/BookDetailState.kt
+++ b/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/BookDetailState.kt
@@ -4,7 +4,7 @@ import com.phase.bookpin.model.book.BookDetail
 import com.phase.bookpin.model.book.Bookmark
 
 data class BookDetailState(
-    val book: BookDetail = BookDetail(),
+    val book: BookDetail = BookDetail.EMPTY,
     val textBookmarks: List<Bookmark> = emptyList(),
     val photoBookmarks: List<Bookmark> = emptyList(),
     val selectedTab: BookmarkTab = BookmarkTab.TEXT,

--- a/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/BookDetailViewModel.kt
+++ b/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/BookDetailViewModel.kt
@@ -11,15 +11,15 @@ class BookDetailViewModel(
     override fun createInitialState(): BookDetailState = BookDetailState()
 
     fun init(bookId: Long) {
-        if (uiState.value.isLoading) return
-        reduce { copy(isLoading = true) }
         loadBookDetail(bookId)
         loadTextBookmarks(bookId)
         loadPhotoBookmarks(bookId)
     }
 
     private fun loadBookDetail(bookId: Long) {
+        if (uiState.value.isLoading) return
         viewModelScope.launch {
+            reduce { copy(isLoading = true) }
             bookRepository
                 .getBookDetail(bookId)
                 .onSuccess { book ->

--- a/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/BookDetailViewModel.kt
+++ b/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/BookDetailViewModel.kt
@@ -1,83 +1,59 @@
 package com.phase.bookpin.bookmark
 
+import androidx.lifecycle.viewModelScope
 import com.phase.bookpin.common.BaseViewModel
+import com.phase.bookpin.domain.book.BookRepository
+import kotlinx.coroutines.launch
 
-class BookDetailViewModel : BaseViewModel<BookDetailState, BookDetailSideEffect>() {
-    override fun createInitialState(): BookDetailState = BookDetailState(
-        book = BookDetail(
-            id = "1",
-            title = "미드나잇 라이브러리",
-            author = "매트 헤이그",
-            coverImageUrl = "",
-            currentPage = 208,
-            totalPages = 320,
-            bookmarkCount = 12,
-        ),
-        bookmarks = listOf(
-            Bookmark(
-                id = "1",
-                pageNumber = 42,
-                quote = "\"후회는 우리가 다르게 살 수 있었다는 희망을 품게 해준다.\"",
-                memo = "이 문장이 정말 와닿았다. 과거에 얽매이지 않고 앞으로 나아가야 한다.",
-                type = BookmarkTab.TEXT,
-            ),
-            Bookmark(
-                id = "2",
-                pageNumber = 78,
-                quote = "\"모든 삶에는 그 자체의 아름다움이 있다.\"",
-                memo = "",
-                type = BookmarkTab.TEXT,
-            ),
-            Bookmark(
-                id = "3",
-                pageNumber = 156,
-                quote = "\"가장 좋은 체스 수는 다음 수다.\"",
-                memo = "인생도 마찬가지. 지금 할 수 있는 최선에 집중하자.",
-                type = BookmarkTab.TEXT,
-            ),
-            Bookmark(
-                id = "4",
-                pageNumber = 23,
-                quote = "\"삶은 가능성으로 가득 차 있다.\"",
-                memo = "첫 번째 사진 북마크 테스트",
-                type = BookmarkTab.PHOTO,
-                photoUrl = "https://picsum.photos/seed/book1/400/400",
-            ),
-            Bookmark(
-                id = "5",
-                pageNumber = 67,
-                quote = "\"우리는 모두 연결되어 있다.\"",
-                memo = "",
-                type = BookmarkTab.PHOTO,
-                photoUrl = "https://picsum.photos/seed/book2/400/400",
-            ),
-            Bookmark(
-                id = "6",
-                pageNumber = 112,
-                quote = "\"변화는 두려운 것이 아니라 새로운 시작이다.\"",
-                memo = "이미지 없는 경우 placeholder 확인용",
-                type = BookmarkTab.PHOTO,
-                photoUrl = null,
-            ),
-            Bookmark(
-                id = "7",
-                pageNumber = 198,
-                quote = "\"시간은 우리가 가진 가장 소중한 자원이다. 그것을 어떻게 쓰느냐가 곧 우리의 삶을 결정한다.\"",
-                memo = "긴 텍스트 말줄임 테스트용",
-                type = BookmarkTab.PHOTO,
-                photoUrl = "https://picsum.photos/seed/book3/400/400",
-            ),
-            Bookmark(
-                id = "8",
-                pageNumber = 245,
-                quote = "\"꿈은 포기하지 않는 한 사라지지 않는다.\"",
-                memo = "",
-                type = BookmarkTab.PHOTO,
-                photoUrl = "https://picsum.photos/seed/book4/400/400",
-            ),
-        ),
-        selectedTab = BookmarkTab.TEXT,
-    )
+class BookDetailViewModel(
+    private val bookRepository: BookRepository,
+) : BaseViewModel<BookDetailState, BookDetailSideEffect>() {
+    override fun createInitialState(): BookDetailState = BookDetailState()
+
+    fun init(bookId: Long) {
+        if (uiState.value.isLoading) return
+        reduce { copy(isLoading = true) }
+        loadBookDetail(bookId)
+        loadTextBookmarks(bookId)
+        loadPhotoBookmarks(bookId)
+    }
+
+    private fun loadBookDetail(bookId: Long) {
+        viewModelScope.launch {
+            bookRepository
+                .getBookDetail(bookId)
+                .onSuccess { book ->
+                    reduce { copy(book = book, isLoading = false) }
+                }.onFailure { error ->
+                    reduce { copy(isLoading = false) }
+                    postSideEffect(BookDetailSideEffect.ShowSnackbar(error.message ?: "오류가 발생했습니다."))
+                }
+        }
+    }
+
+    private fun loadTextBookmarks(bookId: Long) {
+        viewModelScope.launch {
+            bookRepository
+                .getTextBookmarks(bookId)
+                .onSuccess { bookmarks ->
+                    reduce { copy(textBookmarks = bookmarks) }
+                }.onFailure { error ->
+                    postSideEffect(BookDetailSideEffect.ShowSnackbar(error.message ?: "오류가 발생했습니다."))
+                }
+        }
+    }
+
+    private fun loadPhotoBookmarks(bookId: Long) {
+        viewModelScope.launch {
+            bookRepository
+                .getPhotoBookmarks(bookId)
+                .onSuccess { bookmarks ->
+                    reduce { copy(photoBookmarks = bookmarks) }
+                }.onFailure { error ->
+                    postSideEffect(BookDetailSideEffect.ShowSnackbar(error.message ?: "오류가 발생했습니다."))
+                }
+        }
+    }
 
     fun onBackClick() {
         postSideEffect(BookDetailSideEffect.NavigateBack)
@@ -95,10 +71,4 @@ class BookDetailViewModel : BaseViewModel<BookDetailState, BookDetailSideEffect>
     fun onAddBookmarkClick() {
         postSideEffect(BookDetailSideEffect.NavigateToAddBookmark)
     }
-
-    val textBookmarkCount: Int
-        get() = uiState.value.bookmarks.count { it.type == BookmarkTab.TEXT }
-
-    val photoBookmarkCount: Int
-        get() = uiState.value.bookmarks.count { it.type == BookmarkTab.PHOTO }
 }

--- a/model/src/commonMain/kotlin/com/phase/bookpin/model/book/BookDetail.kt
+++ b/model/src/commonMain/kotlin/com/phase/bookpin/model/book/BookDetail.kt
@@ -1,0 +1,12 @@
+package com.phase.bookpin.model.book
+
+data class BookDetail(
+    val id: Long = 0,
+    val title: String = "",
+    val author: String = "",
+    val imageUrl: String = "",
+    val totalPage: Int = 0,
+    val currentPage: Int = 0,
+    val progress: Double = 0.0,
+    val isCompleted: Boolean = false,
+)

--- a/model/src/commonMain/kotlin/com/phase/bookpin/model/book/BookDetail.kt
+++ b/model/src/commonMain/kotlin/com/phase/bookpin/model/book/BookDetail.kt
@@ -1,12 +1,25 @@
 package com.phase.bookpin.model.book
 
 data class BookDetail(
-    val id: Long = 0,
-    val title: String = "",
-    val author: String = "",
-    val imageUrl: String = "",
-    val totalPage: Int = 0,
-    val currentPage: Int = 0,
-    val progress: Double = 0.0,
-    val isCompleted: Boolean = false,
-)
+    val id: Long,
+    val title: String,
+    val author: String,
+    val imageUrl: String,
+    val totalPage: Int,
+    val currentPage: Int,
+    val progress: Double,
+    val isCompleted: Boolean,
+) {
+    companion object {
+        val EMPTY = BookDetail(
+            id = 0,
+            title = "",
+            author = "",
+            imageUrl = "",
+            totalPage = 0,
+            currentPage = 0,
+            progress = 0.0,
+            isCompleted = false,
+        )
+    }
+}

--- a/model/src/commonMain/kotlin/com/phase/bookpin/model/book/Bookmark.kt
+++ b/model/src/commonMain/kotlin/com/phase/bookpin/model/book/Bookmark.kt
@@ -1,0 +1,10 @@
+package com.phase.bookpin.model.book
+
+data class Bookmark(
+    val id: Long = 0,
+    val bookId: Long = 0,
+    val pageNumber: Int = 0,
+    val extractedText: String = "",
+    val note: String = "",
+    val imageUrl: String = "",
+)

--- a/model/src/commonMain/kotlin/com/phase/bookpin/model/book/Bookmark.kt
+++ b/model/src/commonMain/kotlin/com/phase/bookpin/model/book/Bookmark.kt
@@ -1,10 +1,10 @@
 package com.phase.bookpin.model.book
 
 data class Bookmark(
-    val id: Long = 0,
-    val bookId: Long = 0,
-    val pageNumber: Int = 0,
-    val extractedText: String = "",
-    val note: String = "",
-    val imageUrl: String = "",
+    val id: Long,
+    val bookId: Long,
+    val pageNumber: Int,
+    val extractedText: String,
+    val note: String,
+    val imageUrl: String,
 )


### PR DESCRIPTION
## Summary
- BookDetailScreen의 하드코딩된 mock 데이터를 서버 API 3개(책 상세, 텍스트 책갈피, 사진 책갈피)로 교체
- Clean Architecture 레이어별 구현: DTO → DataSource → Repository → ViewModel → Screen
- 도메인 모델(`BookDetail`, `Bookmark`)을 model 모듈에 추가하여 feature 모듈이 data-remote에 의존하지 않도록 설계

## Changes
- **core/data-api**: `BookDetailResponse`, `BookmarkResponse` DTO 추가, `BookRemoteDataSource` 인터페이스에 3개 메서드 추가
- **core/data-remote**: `BookRemoteDataSourceImpl`에 API 호출 구현 (`GET /api/v1/books/{bookId}`, `GET .../bookmarks/text`, `GET .../bookmarks/photo`)
- **core/data-remote**: `RemoteException`이 `detail`을 `Exception.message`로 전달하도록 수정
- **model**: `BookDetail`, `Bookmark` 도메인 모델 추가
- **domain**: `BookRepository` 인터페이스에 3개 메서드 추가
- **core/data**: `BookRepositoryImpl`에 3개 메서드 구현
- **feature/bookmark**: `BookDetailState`를 도메인 모델 기반으로 리팩토링 (`textBookmarks`/`photoBookmarks` 분리)
- **feature/bookmark**: `BookDetailViewModel` mock 데이터 제거, Repository 주입 및 API 병렬 호출
- **feature/bookmark**: `BookDetailScreen` UI 필드 매핑 업데이트 및 로딩 상태 추가

## Test plan
- [ ] `./gradlew :android-app:assembleDebug` 빌드 성공 확인
- [ ] `./gradlew ktlintCheck` 코드 스타일 통과 확인
- [ ] BookDetailScreen 진입 시 API 호출 → 데이터 로딩 → 화면 표시
- [ ] 텍스트/사진 탭 전환 시 각 타입 책갈피 정상 표시
- [ ] API 에러 시 스낵바 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)