### PR TITLE
#48 : 세션 만료 시 토큰만 삭제하고 Splash에서 재로그인

### DIFF
--- a/core/data-api/src/commonMain/kotlin/com/phase/bookpin/data/api/datastore/BookPinPreferenceDataStore.kt
+++ b/core/data-api/src/commonMain/kotlin/com/phase/bookpin/data/api/datastore/BookPinPreferenceDataStore.kt
@@ -5,5 +5,6 @@ import kotlinx.coroutines.flow.Flow
 interface BookPinPreferenceDataStore {
     fun getString(key: DataStoreKey): Flow<String?>
     suspend fun saveString(key: DataStoreKey, value: String)
+    suspend fun remove(key: DataStoreKey)
     suspend fun clear()
 }

--- a/core/data-local/src/commonMain/kotlin/com/phase/bookpin/data/local/datastore/BookPinPreferenceDataStoreImpl.kt
+++ b/core/data-local/src/commonMain/kotlin/com/phase/bookpin/data/local/datastore/BookPinPreferenceDataStoreImpl.kt
@@ -24,6 +24,12 @@ class BookPinPreferenceDataStoreImpl(
         }
     }
 
+    override suspend fun remove(key: DataStoreKey) {
+        dataStore.edit { preferences ->
+            preferences.remove(stringPreferencesKey(key.key))
+        }
+    }
+
     override suspend fun clear() {
         dataStore.edit { preferences ->
             preferences.clear()

--- a/core/data/src/commonMain/kotlin/com/phase/bookpin/data/auth/AuthRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/com/phase/bookpin/data/auth/AuthRepositoryImpl.kt
@@ -6,6 +6,7 @@ import com.phase.bookpin.data.api.datastore.BookPinPreferenceDataStore
 import com.phase.bookpin.data.api.datastore.DataStoreKey
 import com.phase.bookpin.domain.auth.AuthRepository
 import com.phase.bookpin.model.auth.DeviceAuthToken
+import kotlinx.coroutines.flow.first
 
 class AuthRepositoryImpl(
     private val dataSource: AuthRemoteDataSource,
@@ -17,4 +18,11 @@ class AuthRepositoryImpl(
                 preferenceDataStore.saveString(DataStoreKey.ACCESS_TOKEN, response.accessToken)
                 preferenceDataStore.saveString(DataStoreKey.REFRESH_TOKEN, response.refreshToken)
             }
+
+    override suspend fun hasAccessToken(): Boolean {
+        val accessToken = preferenceDataStore
+            .getString(DataStoreKey.ACCESS_TOKEN)
+            .first()
+        return !accessToken.isNullOrEmpty()
+    }
 }

--- a/core/data/src/commonMain/kotlin/com/phase/bookpin/data/auth/SessionRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/com/phase/bookpin/data/auth/SessionRepositoryImpl.kt
@@ -2,6 +2,7 @@ package com.phase.bookpin.data.auth
 
 import com.phase.bookpin.data.api.auth.SessionEventListener
 import com.phase.bookpin.data.api.datastore.BookPinPreferenceDataStore
+import com.phase.bookpin.data.api.datastore.DataStoreKey
 import com.phase.bookpin.domain.auth.SessionRepository
 import com.phase.bookpin.model.auth.SessionEvent
 import kotlinx.coroutines.channels.Channel
@@ -23,6 +24,8 @@ class SessionRepositoryImpl(
     }
 
     override suspend fun clearSession() {
-        preferenceDataStore.clear()
+        preferenceDataStore.remove(DataStoreKey.ACCESS_TOKEN)
+        preferenceDataStore.remove(DataStoreKey.REFRESH_TOKEN)
+        preferenceDataStore.remove(DataStoreKey.REFRESH_TOKEN_EXPIRED_AT)
     }
 }

--- a/domain/src/commonMain/kotlin/com/phase/bookpin/domain/auth/AuthRepository.kt
+++ b/domain/src/commonMain/kotlin/com/phase/bookpin/domain/auth/AuthRepository.kt
@@ -4,4 +4,5 @@ import com.phase.bookpin.model.auth.DeviceAuthToken
 
 interface AuthRepository {
     suspend fun login(token: DeviceAuthToken): Result<Unit>
+    suspend fun hasAccessToken(): Boolean
 }

--- a/feature/splash/src/commonMain/kotlin/com/phase/bookpin/splash/SplashViewModel.kt
+++ b/feature/splash/src/commonMain/kotlin/com/phase/bookpin/splash/SplashViewModel.kt
@@ -28,8 +28,7 @@ class SplashViewModel(
         viewModelScope.launch {
             val start = Clock.System.now()
 
-            val deviceIdResult = deviceRepository.getDeviceId()
-            if (deviceIdResult.isFailure) {
+            if (!authRepository.hasAccessToken()) {
                 val loginResult = login()
                 if (loginResult.isFailure) {
                     postSideEffect(
@@ -51,14 +50,9 @@ class SplashViewModel(
 
     @OptIn(ExperimentalUuidApi::class)
     private suspend fun login(): Result<Unit> {
-        val newDeviceId = Uuid.random().toString()
-        val loginResult = authRepository.login(DeviceAuthToken(newDeviceId))
-
-        if (loginResult.isSuccess) {
-            deviceRepository.saveDeviceId(newDeviceId)
-        }
-
-        return loginResult
+        val deviceId = deviceRepository.getDeviceId().getOrNull()
+            ?: Uuid.random().toString().also { deviceRepository.saveDeviceId(it) }
+        return authRepository.login(DeviceAuthToken(deviceId))
     }
 
     companion object {


### PR DESCRIPTION
## 1. 📄 관련된 이슈 및 소개
- 관련 이슈: closes #48
- 소개: 세션 만료(refreshToken invalid) 시 DataStore 전체를 삭제하던 방식을 토큰만 선택 삭제하도록 개선하고, Splash에서 accessToken 기반으로 재로그인 여부를 판단하도록 변경

## 2. 🔥 변경된 점
- `BookPinPreferenceDataStore`에 `remove(key)` 메서드 추가
- `clearSession()`에서 `clear()` 대신 accessToken, refreshToken, refreshTokenExpiredAt만 선택 삭제 (deviceId 유지)
- `AuthRepository`에 `hasAccessToken()` 메서드 추가 (DataStore의 accessToken 존재 여부 확인)
- `SplashViewModel.startSplash()`에서 deviceId 체크 대신 accessToken 유무로 로그인 판단
- `login()` 시 기존 deviceId를 재사용하고, 없을 때만 새로 생성

## 3. ✅ 필수 체크 사항
- [x] 빌드 확인
- [ ] 테스트 확인
- [ ] 코드 리뷰 요청

## 4. 📸 작업물 사진 공유(선택)
해당 없음

## 5. 💡 알게된 혹은 궁금한 사항
- 기존에는 `clearSession()` 호출 시 deviceId도 함께 삭제되어 매번 새로운 deviceId가 생성되었으나, 이제 deviceId를 유지하여 불필요한 재생성을 방지합니다.
- Splash에서 accessToken이 있으면 login API를 호출하지 않으므로, 정상 앱 시작 시 네트워크 비용이 없습니다.