### PR TITLE
#47 : 이미지 크롭 + OCR 텍스트 자동 추출 기능 추가

### DIFF
--- a/android-app/src/main/AndroidManifest.xml
+++ b/android-app/src/main/AndroidManifest.xml
@@ -21,6 +21,9 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity
+            android:name="com.canhub.cropper.CropImageActivity"
+            android:theme="@style/Theme.AppCompat" />
         <provider
             android:name="androidx.core.content.FileProvider"
             android:authorities="${applicationId}.fileprovider"

--- a/feature/bookmark/build.gradle.kts
+++ b/feature/bookmark/build.gradle.kts
@@ -45,6 +45,9 @@ kotlin {
         }
         androidMain.dependencies {
             implementation(libs.androidx.activity.compose)
+            implementation(libs.android.image.cropper)
+            implementation(libs.mlkit.text.recognition)
+            implementation(libs.mlkit.text.recognition.korean)
         }
         commonTest.dependencies {
             implementation(libs.kotlin.test)

--- a/feature/bookmark/src/androidMain/kotlin/com/phase/bookpin/bookmark/add/ImageCropper.android.kt
+++ b/feature/bookmark/src/androidMain/kotlin/com/phase/bookpin/bookmark/add/ImageCropper.android.kt
@@ -1,0 +1,70 @@
+package com.phase.bookpin.bookmark.add
+
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.Build
+import android.os.Bundle
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContract
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import com.canhub.cropper.CropImage
+import com.canhub.cropper.CropImageActivity
+import com.canhub.cropper.CropImageOptions
+import com.canhub.cropper.CropImageView
+
+actual class ImageCropper(
+    private val onLaunch: (String) -> Unit,
+) {
+    actual fun launch(imageUri: String) = onLaunch(imageUri)
+}
+
+private class BookPinCropImageContract : ActivityResultContract<Uri, Uri?>() {
+    override fun createIntent(context: Context, input: Uri): Intent =
+        Intent(context, CropImageActivity::class.java).apply {
+            val bundle = Bundle().apply {
+                putParcelable(CropImage.CROP_IMAGE_EXTRA_SOURCE, input)
+                putParcelable(
+                    CropImage.CROP_IMAGE_EXTRA_OPTIONS,
+                    CropImageOptions(
+                        guidelines = CropImageView.Guidelines.ON,
+                        fixAspectRatio = false,
+                    ),
+                )
+            }
+            putExtra(CropImage.CROP_IMAGE_EXTRA_BUNDLE, bundle)
+        }
+
+    override fun parseResult(resultCode: Int, intent: Intent?): Uri? {
+        if (resultCode != Activity.RESULT_OK || intent == null) return null
+        val result = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            intent.getParcelableExtra(
+                CropImage.CROP_IMAGE_EXTRA_RESULT,
+                CropImage.ActivityResult::class.java,
+            )
+        } else {
+            @Suppress("DEPRECATION")
+            intent.getParcelableExtra(CropImage.CROP_IMAGE_EXTRA_RESULT)
+        }
+        return result?.uriContent
+    }
+}
+
+@Composable
+actual fun rememberImageCropper(
+    onImageCropped: (String?) -> Unit,
+): ImageCropper {
+    val cropLauncher = rememberLauncherForActivityResult(
+        contract = BookPinCropImageContract(),
+    ) { uri ->
+        onImageCropped(uri?.toString())
+    }
+
+    return remember {
+        ImageCropper { imageUri ->
+            cropLauncher.launch(Uri.parse(imageUri))
+        }
+    }
+}

--- a/feature/bookmark/src/androidMain/kotlin/com/phase/bookpin/bookmark/add/TextRecognizer.android.kt
+++ b/feature/bookmark/src/androidMain/kotlin/com/phase/bookpin/bookmark/add/TextRecognizer.android.kt
@@ -1,0 +1,33 @@
+package com.phase.bookpin.bookmark.add
+
+import android.content.Context
+import androidx.core.net.toUri
+import com.google.mlkit.vision.common.InputImage
+import com.google.mlkit.vision.text.TextRecognition
+import com.google.mlkit.vision.text.korean.KoreanTextRecognizerOptions
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlin.coroutines.resume
+
+actual class TextRecognizer(
+    private val context: Context,
+) {
+    private val recognizer = TextRecognition.getClient(
+        KoreanTextRecognizerOptions.Builder().build(),
+    )
+
+    actual suspend fun recognizeText(imageUri: String): Result<String> =
+        suspendCancellableCoroutine { continuation ->
+            val image = InputImage.fromFilePath(context, imageUri.toUri())
+            val task = recognizer.process(image)
+            task.addOnSuccessListener { visionText ->
+                continuation.resume(Result.success(visionText.text))
+            }
+            task.addOnFailureListener { e ->
+                continuation.resume(Result.failure(e))
+            }
+        }
+
+    actual fun close() {
+        recognizer.close()
+    }
+}

--- a/feature/bookmark/src/androidMain/kotlin/com/phase/bookpin/bookmark/di/BookmarkPlatformModule.android.kt
+++ b/feature/bookmark/src/androidMain/kotlin/com/phase/bookpin/bookmark/di/BookmarkPlatformModule.android.kt
@@ -6,5 +6,5 @@ import org.koin.core.module.Module
 import org.koin.dsl.module
 
 actual val bookmarkPlatformModule: Module = module {
-    single { TextRecognizer(androidContext()) }
+    factory { TextRecognizer(androidContext()) }
 }

--- a/feature/bookmark/src/androidMain/kotlin/com/phase/bookpin/bookmark/di/BookmarkPlatformModule.android.kt
+++ b/feature/bookmark/src/androidMain/kotlin/com/phase/bookpin/bookmark/di/BookmarkPlatformModule.android.kt
@@ -1,0 +1,10 @@
+package com.phase.bookpin.bookmark.di
+
+import com.phase.bookpin.bookmark.add.TextRecognizer
+import org.koin.android.ext.koin.androidContext
+import org.koin.core.module.Module
+import org.koin.dsl.module
+
+actual val bookmarkPlatformModule: Module = module {
+    single { TextRecognizer(androidContext()) }
+}

--- a/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/add/AddBookmarkScreen.kt
+++ b/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/add/AddBookmarkScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -44,8 +45,18 @@ fun AddBookmarkScreen(
     val state by viewModel.uiState.collectAsStateWithLifecycle()
     val snackbarHost = LocalSnackbarHost.current
 
+    val imageCropper = rememberImageCropper(
+        onImageCropped = viewModel::onCroppedImageReady,
+    )
+
     val imagePickerLauncher = rememberImagePickerLauncher(
-        onImagePicked = viewModel::onPhotoUriChanged,
+        onImagePicked = { uri ->
+            if (uri != null) {
+                imageCropper.launch(uri)
+            } else {
+                viewModel.onPhotoUriChanged(null)
+            }
+        },
     )
 
     val launchPicker = remember(imagePickerLauncher) {
@@ -110,12 +121,30 @@ fun AddBookmarkScreen(
 
             Spacer(modifier = Modifier.height(8.dp))
 
-            BPTextArea(
-                value = state.extractedText,
-                onValueChange = viewModel::onExtractedTextChanged,
-                placeholder = stringResource(Res.string.bookmark_extracted_text_placeholder),
-                minHeight = 172.dp,
-            )
+            Box {
+                BPTextArea(
+                    value = state.extractedText,
+                    onValueChange = viewModel::onExtractedTextChanged,
+                    placeholder = stringResource(Res.string.bookmark_extracted_text_placeholder),
+                    minHeight = 172.dp,
+                )
+                if (state.isOcrProcessing) {
+                    Box(
+                        modifier = Modifier
+                            .matchParentSize()
+                            .background(
+                                BookPinTheme.colors.bgSurface.copy(alpha = 0.6f),
+                                RoundedCornerShape(12.dp),
+                            ),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        CircularProgressIndicator(
+                            color = BookPinTheme.colors.buttonPrimary,
+                            modifier = Modifier.size(36.dp),
+                        )
+                    }
+                }
+            }
 
             Spacer(modifier = Modifier.height(20.dp))
 

--- a/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/add/AddBookmarkState.kt
+++ b/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/add/AddBookmarkState.kt
@@ -9,4 +9,5 @@ data class AddBookmarkState(
     val pageNumber: String = "",
     val personalMemo: String = "",
     val isLoading: Boolean = false,
+    val isOcrProcessing: Boolean = false,
 )

--- a/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/add/AddBookmarkViewModel.kt
+++ b/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/add/AddBookmarkViewModel.kt
@@ -1,9 +1,13 @@
 package com.phase.bookpin.bookmark.add
 
+import androidx.lifecycle.viewModelScope
 import com.phase.bookpin.common.BaseViewModel
 import com.phase.bookpin.model.bookmark.BookmarkType
+import kotlinx.coroutines.launch
 
-class AddBookmarkViewModel : BaseViewModel<AddBookmarkState, AddBookmarkSideEffect>() {
+class AddBookmarkViewModel(
+    private val textRecognizer: TextRecognizer,
+) : BaseViewModel<AddBookmarkState, AddBookmarkSideEffect>() {
     override fun createInitialState(): AddBookmarkState = AddBookmarkState()
 
     fun initBookmarkType(type: BookmarkType) {
@@ -31,7 +35,34 @@ class AddBookmarkViewModel : BaseViewModel<AddBookmarkState, AddBookmarkSideEffe
         reduce { copy(photoUri = uri) }
     }
 
+    fun onCroppedImageReady(uri: String?) {
+        if (uri == null) {
+            reduce { copy(photoUri = null) }
+            return
+        }
+        reduce { copy(photoUri = uri, isOcrProcessing = true) }
+        viewModelScope.launch {
+            val result = textRecognizer.recognizeText(uri)
+            result.onSuccess { text ->
+                reduce { copy(extractedText = text, isOcrProcessing = false) }
+            }
+            result.onFailure { error ->
+                reduce { copy(isOcrProcessing = false) }
+                postSideEffect(
+                    AddBookmarkSideEffect.ShowSnackbar(
+                        error.message ?: "텍스트 인식에 실패했습니다.",
+                    ),
+                )
+            }
+        }
+    }
+
     fun onCloseClick() {
         postSideEffect(AddBookmarkSideEffect.NavigateBack)
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        textRecognizer.close()
     }
 }

--- a/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/add/ImageCropper.kt
+++ b/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/add/ImageCropper.kt
@@ -1,0 +1,12 @@
+package com.phase.bookpin.bookmark.add
+
+import androidx.compose.runtime.Composable
+
+expect class ImageCropper {
+    fun launch(imageUri: String)
+}
+
+@Composable
+expect fun rememberImageCropper(
+    onImageCropped: (String?) -> Unit,
+): ImageCropper

--- a/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/add/TextRecognizer.kt
+++ b/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/add/TextRecognizer.kt
@@ -1,0 +1,6 @@
+package com.phase.bookpin.bookmark.add
+
+expect class TextRecognizer {
+    suspend fun recognizeText(imageUri: String): Result<String>
+    fun close()
+}

--- a/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/di/BookDetailModule.kt
+++ b/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/di/BookDetailModule.kt
@@ -6,6 +6,7 @@ import org.koin.core.module.dsl.viewModelOf
 import org.koin.dsl.module
 
 val bookDetailModule = module {
+    includes(bookmarkPlatformModule)
     viewModelOf(::BookDetailViewModel)
     viewModelOf(::AddBookmarkViewModel)
 }

--- a/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/di/BookmarkPlatformModule.kt
+++ b/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/di/BookmarkPlatformModule.kt
@@ -1,0 +1,5 @@
+package com.phase.bookpin.bookmark.di
+
+import org.koin.core.module.Module
+
+expect val bookmarkPlatformModule: Module

--- a/feature/bookmark/src/iosMain/kotlin/com/phase/bookpin/bookmark/add/ImageCropper.ios.kt
+++ b/feature/bookmark/src/iosMain/kotlin/com/phase/bookpin/bookmark/add/ImageCropper.ios.kt
@@ -1,0 +1,17 @@
+package com.phase.bookpin.bookmark.add
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+
+actual class ImageCropper(
+    private val onLaunch: (String) -> Unit,
+) {
+    actual fun launch(imageUri: String) = onLaunch(imageUri)
+}
+
+@Composable
+actual fun rememberImageCropper(
+    onImageCropped: (String?) -> Unit,
+): ImageCropper = remember {
+    ImageCropper { /* iOS: not yet implemented */ }
+}

--- a/feature/bookmark/src/iosMain/kotlin/com/phase/bookpin/bookmark/add/TextRecognizer.ios.kt
+++ b/feature/bookmark/src/iosMain/kotlin/com/phase/bookpin/bookmark/add/TextRecognizer.ios.kt
@@ -1,0 +1,8 @@
+package com.phase.bookpin.bookmark.add
+
+actual class TextRecognizer {
+    actual suspend fun recognizeText(imageUri: String): Result<String> =
+        Result.failure(NotImplementedError("iOS TextRecognizer not yet implemented"))
+
+    actual fun close() { /* no-op */ }
+}

--- a/feature/bookmark/src/iosMain/kotlin/com/phase/bookpin/bookmark/di/BookmarkPlatformModule.ios.kt
+++ b/feature/bookmark/src/iosMain/kotlin/com/phase/bookpin/bookmark/di/BookmarkPlatformModule.ios.kt
@@ -1,0 +1,9 @@
+package com.phase.bookpin.bookmark.di
+
+import com.phase.bookpin.bookmark.add.TextRecognizer
+import org.koin.core.module.Module
+import org.koin.dsl.module
+
+actual val bookmarkPlatformModule: Module = module {
+    single { TextRecognizer() }
+}

--- a/feature/bookmark/src/iosMain/kotlin/com/phase/bookpin/bookmark/di/BookmarkPlatformModule.ios.kt
+++ b/feature/bookmark/src/iosMain/kotlin/com/phase/bookpin/bookmark/di/BookmarkPlatformModule.ios.kt
@@ -5,5 +5,5 @@ import org.koin.core.module.Module
 import org.koin.dsl.module
 
 actual val bookmarkPlatformModule: Module = module {
-    single { TextRecognizer() }
+    factory { TextRecognizer() }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -45,6 +45,8 @@ kotlinStdlib = "2.3.0"
 runner = "1.7.0"
 core = "1.7.0"
 buildKonfig = "0.17.1"
+android-image-cropper = "4.7.0"
+mlkit-text-recognition = "16.0.1"
 
 [libraries]
 androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "androidx-core" }
@@ -114,6 +116,10 @@ androidx-runner = { group = "androidx.test", name = "runner", version.ref = "run
 androidx-core = { group = "androidx.test", name = "core", version.ref = "core" }
 
 kermit = { group = "co.touchlab", name = "kermit", version.ref = "kermit" }
+
+android-image-cropper = { module = "com.vanniktech:android-image-cropper", version.ref = "android-image-cropper" }
+mlkit-text-recognition = { module = "com.google.mlkit:text-recognition", version.ref = "mlkit-text-recognition" }
+mlkit-text-recognition-korean = { module = "com.google.mlkit:text-recognition-korean", version.ref = "mlkit-text-recognition" }
 
 [bundles]
 ktor-shared = [


### PR DESCRIPTION
closes #47

## 1. 📄 관련된 이슈 및 소개
- 관련 이슈: #47
- 소개: 사진 북마크 추가 플로우에서 이미지 크롭과 OCR 텍스트 자동 추출 기능을 추가합니다. 기존에는 사진 선택 후 직접 텍스트를 입력해야 했지만, 이제 크롭 → OCR 파이프라인을 통해 텍스트가 자동으로 채워집니다.

## 2. 🔥 변경된 점
- **이미지 크롭**: Android-Image-Cropper 라이브러리를 활용한 크롭 기능 추가 (자유 비율, 가이드라인 ON)
- **OCR 텍스트 인식**: Google ML Kit Text Recognition V2 (한국어 + Latin) 연동
- **expect/actual 패턴**: ImageCropper, TextRecognizer를 KMP expect/actual로 구현하여 iOS 스텁 유지
- **DI 설정**: bookmarkPlatformModule을 통한 플랫폼별 TextRecognizer 주입
- **UI 변경**: OCR 처리 중 CircularProgressIndicator 오버레이 표시
- **파이프라인 연결**: 사진 선택 → 크롭 → OCR → 텍스트 자동 채움 플로우 완성
- **AndroidManifest**: CropImageActivity에 AppCompat 테마 등록

## 3. ✅ 필수 체크 사항
- [x] 빌드 확인
- [x] KtLint 확인
- [ ] 코드 리뷰 요청

## 4. 📸 작업물 사진 공유(선택)

## 5. 💡 알게된 혹은 궁금한 사항
- `CropImageContract` / `CropImageContractOptions`가 deprecated되어 커스텀 `ActivityResultContract`를 직접 구현했습니다
- `getParcelableExtra`도 API 33 기준으로 분기 처리하여 deprecated 경고를 해소했습니다
- iOS는 expect/actual 스텁만 유지하며, 추후 별도 구현이 필요합니다