### PR TITLE
#54 : 설정 화면 유저 정보 API 연동 및 북마크 섹션 리디자인

### DIFF
--- a/core/data-api/src/commonMain/kotlin/com/phase/bookpin/data/api/book/LatestBookmarkResponse.kt
+++ b/core/data-api/src/commonMain/kotlin/com/phase/bookpin/data/api/book/LatestBookmarkResponse.kt
@@ -7,6 +7,7 @@ import kotlinx.serialization.Serializable
 data class LatestBookmarkResponse(
     val id: Long,
     val bookId: Long,
+    val bookTitle: String = "",
     val pageNumber: Int = 0,
     val extractedText: String = "",
     val note: String = "",
@@ -16,6 +17,7 @@ data class LatestBookmarkResponse(
     fun toLatestBookmark(): LatestBookmark = LatestBookmark(
         id = id,
         bookId = bookId,
+        bookTitle = bookTitle,
         pageNumber = pageNumber,
         extractedText = extractedText,
         note = note,

--- a/core/data-api/src/commonMain/kotlin/com/phase/bookpin/data/api/datastore/DataStoreKey.kt
+++ b/core/data-api/src/commonMain/kotlin/com/phase/bookpin/data/api/datastore/DataStoreKey.kt
@@ -5,4 +5,7 @@ enum class DataStoreKey(val key: String) {
     REFRESH_TOKEN("refresh_token"),
     REFRESH_TOKEN_EXPIRED_AT("refresh_token_expired_at"),
     DEVICE_ID("device_id"),
+    USER_ID("user_id"),
+    USER_NICKNAME("user_nickname"),
+    USER_PROFILE_IMAGE_URL("user_profile_image_url"),
 }

--- a/core/data-api/src/commonMain/kotlin/com/phase/bookpin/data/api/user/UserRemoteDataSource.kt
+++ b/core/data-api/src/commonMain/kotlin/com/phase/bookpin/data/api/user/UserRemoteDataSource.kt
@@ -1,0 +1,5 @@
+package com.phase.bookpin.data.api.user
+
+interface UserRemoteDataSource {
+    suspend fun getUser(): Result<UserResponse>
+}

--- a/core/data-api/src/commonMain/kotlin/com/phase/bookpin/data/api/user/UserResponse.kt
+++ b/core/data-api/src/commonMain/kotlin/com/phase/bookpin/data/api/user/UserResponse.kt
@@ -1,0 +1,17 @@
+package com.phase.bookpin.data.api.user
+
+import com.phase.bookpin.model.user.User
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class UserResponse(
+    val id: Long,
+    val nickname: String = "",
+    val profileImageUrl: String = "",
+) {
+    fun toUser(): User = User(
+        id = id,
+        nickname = nickname,
+        profileImageUrl = profileImageUrl,
+    )
+}

--- a/core/data-remote/src/commonMain/kotlin/com/phase/bookpin/data/remote/di/DataRemoteModule.kt
+++ b/core/data-remote/src/commonMain/kotlin/com/phase/bookpin/data/remote/di/DataRemoteModule.kt
@@ -3,9 +3,11 @@ package com.phase.bookpin.data.remote.di
 import com.phase.bookpin.data.api.auth.AuthRemoteDataSource
 import com.phase.bookpin.data.api.book.BookRemoteDataSource
 import com.phase.bookpin.data.api.search.SearchRemoteDataSource
+import com.phase.bookpin.data.api.user.UserRemoteDataSource
 import com.phase.bookpin.data.remote.auth.AuthRemoteDataSourceImpl
 import com.phase.bookpin.data.remote.book.BookRemoteDataSourceImpl
 import com.phase.bookpin.data.remote.search.SearchRemoteDataSourceImpl
+import com.phase.bookpin.data.remote.user.UserRemoteDataSourceImpl
 import com.phase.bookpin.data.remote.client.createHttpClient
 import com.phase.bookpin.data.remote.client.createRefreshHttpClient
 import io.ktor.client.HttpClient
@@ -33,5 +35,8 @@ val dataRemoteModule = module {
     }
     single<SearchRemoteDataSource> {
         SearchRemoteDataSourceImpl(httpClient = get())
+    }
+    single<UserRemoteDataSource> {
+        UserRemoteDataSourceImpl(httpClient = get())
     }
 }

--- a/core/data-remote/src/commonMain/kotlin/com/phase/bookpin/data/remote/user/UserRemoteDataSourceImpl.kt
+++ b/core/data-remote/src/commonMain/kotlin/com/phase/bookpin/data/remote/user/UserRemoteDataSourceImpl.kt
@@ -1,0 +1,20 @@
+package com.phase.bookpin.data.remote.user
+
+import com.phase.bookpin.data.api.user.UserRemoteDataSource
+import com.phase.bookpin.data.api.user.UserResponse
+import com.phase.bookpin.data.remote.client.safeRequest
+import io.ktor.client.HttpClient
+import io.ktor.http.HttpMethod
+import io.ktor.http.path
+
+class UserRemoteDataSourceImpl(
+    private val httpClient: HttpClient,
+) : UserRemoteDataSource {
+    override suspend fun getUser(): Result<UserResponse> =
+        httpClient.safeRequest {
+            url {
+                method = HttpMethod.Get
+                path("api/v1/users/me")
+            }
+        }
+}

--- a/core/data/src/commonMain/kotlin/com/phase/bookpin/data/auth/SessionRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/com/phase/bookpin/data/auth/SessionRepositoryImpl.kt
@@ -27,5 +27,8 @@ class SessionRepositoryImpl(
         preferenceDataStore.remove(DataStoreKey.ACCESS_TOKEN)
         preferenceDataStore.remove(DataStoreKey.REFRESH_TOKEN)
         preferenceDataStore.remove(DataStoreKey.REFRESH_TOKEN_EXPIRED_AT)
+        preferenceDataStore.remove(DataStoreKey.USER_ID)
+        preferenceDataStore.remove(DataStoreKey.USER_NICKNAME)
+        preferenceDataStore.remove(DataStoreKey.USER_PROFILE_IMAGE_URL)
     }
 }

--- a/core/data/src/commonMain/kotlin/com/phase/bookpin/data/di/DataModule.kt
+++ b/core/data/src/commonMain/kotlin/com/phase/bookpin/data/di/DataModule.kt
@@ -6,11 +6,13 @@ import com.phase.bookpin.data.auth.SessionRepositoryImpl
 import com.phase.bookpin.data.book.BookRepositoryImpl
 import com.phase.bookpin.data.device.DeviceRepositoryImpl
 import com.phase.bookpin.data.search.SearchRepositoryImpl
+import com.phase.bookpin.data.user.UserRepositoryImpl
 import com.phase.bookpin.domain.auth.AuthRepository
 import com.phase.bookpin.domain.auth.SessionRepository
 import com.phase.bookpin.domain.book.BookRepository
 import com.phase.bookpin.domain.device.DeviceRepository
 import com.phase.bookpin.domain.search.SearchRepository
+import com.phase.bookpin.domain.user.UserRepository
 import org.koin.core.module.dsl.bind
 import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.module
@@ -24,4 +26,5 @@ val dataModule = module {
     singleOf(::DeviceRepositoryImpl) { bind<DeviceRepository>() }
     singleOf(::BookRepositoryImpl) { bind<BookRepository>() }
     singleOf(::SearchRepositoryImpl) { bind<SearchRepository>() }
+    singleOf(::UserRepositoryImpl) { bind<UserRepository>() }
 }

--- a/core/data/src/commonMain/kotlin/com/phase/bookpin/data/user/UserRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/com/phase/bookpin/data/user/UserRepositoryImpl.kt
@@ -1,0 +1,31 @@
+package com.phase.bookpin.data.user
+
+import com.phase.bookpin.data.api.datastore.BookPinPreferenceDataStore
+import com.phase.bookpin.data.api.datastore.DataStoreKey
+import com.phase.bookpin.data.api.user.UserRemoteDataSource
+import com.phase.bookpin.domain.user.UserRepository
+import com.phase.bookpin.model.user.User
+import kotlinx.coroutines.flow.first
+
+class UserRepositoryImpl(
+    private val remoteDataSource: UserRemoteDataSource,
+    private val preferenceDataStore: BookPinPreferenceDataStore,
+) : UserRepository {
+    override suspend fun getUser(): Result<User> {
+        val cachedId = preferenceDataStore.getString(DataStoreKey.USER_ID).first()
+        val cachedNickname = preferenceDataStore.getString(DataStoreKey.USER_NICKNAME).first()
+        val cachedImage = preferenceDataStore.getString(DataStoreKey.USER_PROFILE_IMAGE_URL).first()
+
+        if (cachedId != null && cachedNickname != null) {
+            return Result.success(User(cachedId.toLong(), cachedNickname, cachedImage.orEmpty()))
+        }
+
+        return remoteDataSource.getUser().mapCatching { response ->
+            val user = response.toUser()
+            preferenceDataStore.saveString(DataStoreKey.USER_ID, user.id.toString())
+            preferenceDataStore.saveString(DataStoreKey.USER_NICKNAME, user.nickname)
+            preferenceDataStore.saveString(DataStoreKey.USER_PROFILE_IMAGE_URL, user.profileImageUrl)
+            user
+        }
+    }
+}

--- a/core/data/src/commonMain/kotlin/com/phase/bookpin/data/user/UserRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/com/phase/bookpin/data/user/UserRepositoryImpl.kt
@@ -12,12 +12,12 @@ class UserRepositoryImpl(
     private val preferenceDataStore: BookPinPreferenceDataStore,
 ) : UserRepository {
     override suspend fun getUser(): Result<User> {
-        val cachedId = preferenceDataStore.getString(DataStoreKey.USER_ID).first()
+        val cachedId = preferenceDataStore.getString(DataStoreKey.USER_ID).first()?.toLongOrNull()
         val cachedNickname = preferenceDataStore.getString(DataStoreKey.USER_NICKNAME).first()
         val cachedImage = preferenceDataStore.getString(DataStoreKey.USER_PROFILE_IMAGE_URL).first()
 
         if (cachedId != null && cachedNickname != null) {
-            return Result.success(User(cachedId.toLong(), cachedNickname, cachedImage.orEmpty()))
+            return Result.success(User(cachedId, cachedNickname, cachedImage.orEmpty()))
         }
 
         return remoteDataSource.getUser().mapCatching { response ->

--- a/domain/src/commonMain/kotlin/com/phase/bookpin/domain/user/UserRepository.kt
+++ b/domain/src/commonMain/kotlin/com/phase/bookpin/domain/user/UserRepository.kt
@@ -1,0 +1,7 @@
+package com.phase.bookpin.domain.user
+
+import com.phase.bookpin.model.user.User
+
+interface UserRepository {
+    suspend fun getUser(): Result<User>
+}

--- a/feature/settings/build.gradle.kts
+++ b/feature/settings/build.gradle.kts
@@ -41,6 +41,7 @@ kotlin {
             implementation(projects.model)
             implementation(projects.domain)
             implementation(libs.koin.compose.viewmodel)
+            implementation(libs.coil.compose)
         }
         commonTest.dependencies {
             implementation(libs.kotlin.test)

--- a/feature/settings/src/commonMain/composeResources/values/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values/strings.xml
@@ -15,4 +15,6 @@
     <string name="cancel">취소</string>
     <string name="confirm_logout">로그아웃</string>
     <string name="confirm_delete">삭제하기</string>
+    <string name="view_all">전체 보기</string>
+    <string name="default_profile_name">독서하는 사람</string>
 </resources>

--- a/feature/settings/src/commonMain/kotlin/com/phase/bookpin/settings/SettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/com/phase/bookpin/settings/SettingsScreen.kt
@@ -75,7 +75,6 @@ fun SettingsScreen(
                 profileName = state.profileName
                     ?: stringResource(Res.string.default_profile_name),
                 profileImageUrl = state.profileImageUrl,
-                accountType = state.accountType,
             )
 
             state.latestBookmark?.let { bookmark ->
@@ -167,7 +166,6 @@ private fun SettingsTopBar(
 private fun ProfileCard(
     profileName: String,
     profileImageUrl: String?,
-    accountType: String,
 ) {
     Row(
         modifier = Modifier
@@ -207,20 +205,11 @@ private fun ProfileCard(
             }
         }
 
-        Column(
-            verticalArrangement = Arrangement.spacedBy(4.dp),
-        ) {
-            Text(
-                text = profileName,
-                style = BookPinTheme.typography.titleMedium,
-                color = BookPinTheme.colors.textPrimary,
-            )
-            Text(
-                text = accountType,
-                style = BookPinTheme.typography.bodySmall,
-                color = BookPinTheme.colors.textSecondary,
-            )
-        }
+        Text(
+            text = profileName,
+            style = BookPinTheme.typography.titleMedium,
+            color = BookPinTheme.colors.textPrimary,
+        )
     }
 }
 

--- a/feature/settings/src/commonMain/kotlin/com/phase/bookpin/settings/SettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/com/phase/bookpin/settings/SettingsScreen.kt
@@ -1,6 +1,7 @@
 package com.phase.bookpin.settings
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
@@ -15,12 +16,15 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import bookpin.settings.generated.resources.*
+import coil3.compose.AsyncImage
 import com.phase.bookpin.common.extensions.collectSideEffect
 import com.phase.bookpin.common.snackbar.LocalSnackbarHost
 import com.phase.bookpin.designsystem.BookPinTheme
@@ -45,6 +49,9 @@ fun SettingsScreen(
             SettingsSideEffect.NavigateBack -> onNavigateBack()
             SettingsSideEffect.Logout -> onLogout()
             SettingsSideEffect.DeleteAccount -> onLogout()
+            SettingsSideEffect.NavigateToAllBookmarks -> {
+                // TODO: Navigate to all bookmarks screen
+            }
         }
     }
 
@@ -65,12 +72,17 @@ fun SettingsScreen(
             Spacer(modifier = Modifier.height(4.dp))
 
             ProfileCard(
-                profileName = state.profileName,
+                profileName = state.profileName
+                    ?: stringResource(Res.string.default_profile_name),
+                profileImageUrl = state.profileImageUrl,
                 accountType = state.accountType,
             )
 
             state.latestBookmark?.let { bookmark ->
-                LatestBookmarkSection(bookmark = bookmark)
+                LatestBookmarkSection(
+                    bookmark = bookmark,
+                    onViewAllClick = viewModel::onViewAllBookmarksClick,
+                )
             }
 
             SettingsSection(
@@ -154,6 +166,7 @@ private fun SettingsTopBar(
 @Composable
 private fun ProfileCard(
     profileName: String,
+    profileImageUrl: String?,
     accountType: String,
 ) {
     Row(
@@ -166,21 +179,32 @@ private fun ProfileCard(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(16.dp),
     ) {
-        Box(
-            modifier = Modifier
-                .size(56.dp)
-                .background(
-                    color = BookPinTheme.colors.bgMuted,
-                    shape = CircleShape,
-                ),
-            contentAlignment = Alignment.Center,
-        ) {
-            Icon(
-                painter = painterResource(Res.drawable.ic_person),
+        if (profileImageUrl != null) {
+            AsyncImage(
+                model = profileImageUrl,
                 contentDescription = null,
-                modifier = Modifier.size(28.dp),
-                tint = BookPinTheme.colors.iconDefault,
+                modifier = Modifier
+                    .size(56.dp)
+                    .clip(CircleShape),
+                contentScale = ContentScale.Crop,
             )
+        } else {
+            Box(
+                modifier = Modifier
+                    .size(56.dp)
+                    .background(
+                        color = BookPinTheme.colors.bgMuted,
+                        shape = CircleShape,
+                    ),
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(
+                    painter = painterResource(Res.drawable.ic_person),
+                    contentDescription = null,
+                    modifier = Modifier.size(28.dp),
+                    tint = BookPinTheme.colors.iconDefault,
+                )
+            }
         }
 
         Column(
@@ -203,16 +227,42 @@ private fun ProfileCard(
 @Composable
 private fun LatestBookmarkSection(
     bookmark: LatestBookmark,
+    onViewAllClick: () -> Unit,
 ) {
     Column(
         verticalArrangement = Arrangement.spacedBy(12.dp),
     ) {
-        Text(
-            text = stringResource(Res.string.achievements_title),
-            style = BookPinTheme.typography.bodyMedium,
-            color = BookPinTheme.colors.textSecondary,
-            modifier = Modifier.padding(start = 4.dp),
-        )
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 4.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = stringResource(Res.string.achievements_title),
+                style = BookPinTheme.typography.bodyMedium,
+                color = BookPinTheme.colors.textSecondary,
+            )
+
+            Row(
+                modifier = Modifier.clickable(onClick = onViewAllClick),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(2.dp),
+            ) {
+                Text(
+                    text = stringResource(Res.string.view_all),
+                    style = BookPinTheme.typography.bodySmall,
+                    color = BookPinTheme.colors.textAccentMuted,
+                )
+                Icon(
+                    painter = painterResource(Res.drawable.ic_chevron_right),
+                    contentDescription = null,
+                    modifier = Modifier.size(14.dp),
+                    tint = BookPinTheme.colors.textAccentMuted,
+                )
+            }
+        }
 
         Column(
             modifier = Modifier
@@ -222,54 +272,66 @@ private fun LatestBookmarkSection(
                     shape = RoundedCornerShape(16.dp),
                 ).padding(16.dp),
         ) {
-            LatestBookmarkItem(bookmark = bookmark)
+            LatestBookmarkCard(bookmark = bookmark)
         }
     }
 }
 
 @Composable
-private fun LatestBookmarkItem(
+private fun LatestBookmarkCard(
     bookmark: LatestBookmark,
 ) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(12.dp),
+            .shadow(
+                elevation = 2.dp,
+                shape = RoundedCornerShape(16.dp),
+            ).background(
+                color = BookPinTheme.colors.bgCanvas,
+                shape = RoundedCornerShape(16.dp),
+            ).border(
+                width = 0.6.dp,
+                color = BookPinTheme.colors.borderSubtle,
+                shape = RoundedCornerShape(16.dp),
+            ).padding(16.dp),
         horizontalArrangement = Arrangement.spacedBy(12.dp),
+        verticalAlignment = Alignment.CenterVertically,
     ) {
-        Text(
-            text = "\uD83D\uDCD6",
-            fontSize = 24.sp,
-        )
-
         Column(
-            verticalArrangement = Arrangement.spacedBy(2.dp),
+            modifier = Modifier.weight(1f),
+            verticalArrangement = Arrangement.spacedBy(6.dp),
         ) {
             Text(
                 text = bookmark.extractedText,
-                style = BookPinTheme.typography.bodyMedium,
+                style = BookPinTheme.typography.bodyLarge,
                 color = BookPinTheme.colors.textPrimary,
-                maxLines = 2,
+                maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
             )
+
+            val subtitle = buildString {
+                if (bookmark.bookTitle.isNotEmpty()) {
+                    append(bookmark.bookTitle)
+                    append(" \u00B7 ")
+                }
+                append(bookmark.createdAt)
+            }
             Text(
-                text = bookmark.note,
+                text = subtitle,
                 style = BookPinTheme.typography.bodySmall,
                 color = BookPinTheme.colors.textSecondary,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
             )
-            Text(
-                text = "${bookmark.pageNumber}p",
-                style = BookPinTheme.typography.bodySmall,
-                color = BookPinTheme.colors.textSecondary,
-            )
-            Text(
-                text = bookmark.createdAt,
-                style = BookPinTheme.typography.bodySmall,
-                color = BookPinTheme.colors.textAccentMuted,
-            )
         }
+
+        Icon(
+            painter = painterResource(Res.drawable.ic_chevron_right),
+            contentDescription = null,
+            modifier = Modifier.size(16.dp),
+            tint = BookPinTheme.colors.iconDefault,
+        )
     }
 }
 

--- a/feature/settings/src/commonMain/kotlin/com/phase/bookpin/settings/SettingsSideEffect.kt
+++ b/feature/settings/src/commonMain/kotlin/com/phase/bookpin/settings/SettingsSideEffect.kt
@@ -7,4 +7,5 @@ sealed interface SettingsSideEffect {
     data object NavigateBack : SettingsSideEffect
     data object Logout : SettingsSideEffect
     data object DeleteAccount : SettingsSideEffect
+    data object NavigateToAllBookmarks : SettingsSideEffect
 }

--- a/feature/settings/src/commonMain/kotlin/com/phase/bookpin/settings/SettingsState.kt
+++ b/feature/settings/src/commonMain/kotlin/com/phase/bookpin/settings/SettingsState.kt
@@ -5,7 +5,6 @@ import com.phase.bookpin.model.book.LatestBookmark
 data class SettingsState(
     val profileName: String? = null,
     val profileImageUrl: String? = null,
-    val accountType: String = "카카오 계정",
     val showLogoutDialog: Boolean = false,
     val showDeleteAccountDialog: Boolean = false,
     val latestBookmark: LatestBookmark? = null,

--- a/feature/settings/src/commonMain/kotlin/com/phase/bookpin/settings/SettingsState.kt
+++ b/feature/settings/src/commonMain/kotlin/com/phase/bookpin/settings/SettingsState.kt
@@ -3,7 +3,8 @@ package com.phase.bookpin.settings
 import com.phase.bookpin.model.book.LatestBookmark
 
 data class SettingsState(
-    val profileName: String = "독서하는 사람",
+    val profileName: String? = null,
+    val profileImageUrl: String? = null,
     val accountType: String = "카카오 계정",
     val showLogoutDialog: Boolean = false,
     val showDeleteAccountDialog: Boolean = false,

--- a/feature/settings/src/commonMain/kotlin/com/phase/bookpin/settings/SettingsViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/com/phase/bookpin/settings/SettingsViewModel.kt
@@ -3,15 +3,33 @@ package com.phase.bookpin.settings
 import androidx.lifecycle.viewModelScope
 import com.phase.bookpin.common.BaseViewModel
 import com.phase.bookpin.domain.book.BookRepository
+import com.phase.bookpin.domain.user.UserRepository
 import kotlinx.coroutines.launch
 
 class SettingsViewModel(
     private val bookRepository: BookRepository,
+    private val userRepository: UserRepository,
 ) : BaseViewModel<SettingsState, SettingsSideEffect>() {
     override fun createInitialState(): SettingsState = SettingsState()
 
     init {
+        loadUserProfile()
         loadLatestBookmark()
+    }
+
+    private fun loadUserProfile() {
+        viewModelScope.launch {
+            userRepository
+                .getUser()
+                .onSuccess { user ->
+                    reduce {
+                        copy(
+                            profileName = user.nickname,
+                            profileImageUrl = user.profileImageUrl.ifEmpty { null },
+                        )
+                    }
+                }
+        }
     }
 
     private fun loadLatestBookmark() {
@@ -32,6 +50,11 @@ class SettingsViewModel(
 
     fun onContactClick() {
         postSideEffect(SettingsSideEffect.ShowSnackbar("문의하기 기능은 준비 중입니다."))
+    }
+
+    fun onViewAllBookmarksClick() {
+        // TODO: Navigate to all bookmarks screen when available
+        postSideEffect(SettingsSideEffect.NavigateToAllBookmarks)
     }
 
     fun onLogoutClick() {

--- a/feature/settings/src/commonMain/kotlin/com/phase/bookpin/settings/SettingsViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/com/phase/bookpin/settings/SettingsViewModel.kt
@@ -28,6 +28,8 @@ class SettingsViewModel(
                             profileImageUrl = user.profileImageUrl.ifEmpty { null },
                         )
                     }
+                }.onFailure {
+                    postSideEffect(SettingsSideEffect.ShowSnackbar("프로필 정보를 불러오지 못했습니다."))
                 }
         }
     }

--- a/model/src/commonMain/kotlin/com/phase/bookpin/model/book/LatestBookmark.kt
+++ b/model/src/commonMain/kotlin/com/phase/bookpin/model/book/LatestBookmark.kt
@@ -3,6 +3,7 @@ package com.phase.bookpin.model.book
 data class LatestBookmark(
     val id: Long,
     val bookId: Long,
+    val bookTitle: String,
     val pageNumber: Int,
     val extractedText: String,
     val note: String,

--- a/model/src/commonMain/kotlin/com/phase/bookpin/model/user/User.kt
+++ b/model/src/commonMain/kotlin/com/phase/bookpin/model/user/User.kt
@@ -1,0 +1,7 @@
+package com.phase.bookpin.model.user
+
+data class User(
+    val id: Long,
+    val nickname: String,
+    val profileImageUrl: String,
+)


### PR DESCRIPTION
## Summary
- `GET /api/v1/users/me` API 연동으로 설정 화면 유저 정보(닉네임, 프로필 이미지) 실제 데이터 표시
- User 도메인 모델 + Repository (로컬 캐시 우선, API 폴백, DataStore 캐시 저장)
- LatestBookmarkSection Figma 디자인 적용 (이모지 제거, 인용문 카드 + 책제목·날짜, 전체 보기 버튼)
- LatestBookmark 모델에 bookTitle 필드 추가
- ProfileCard에 Coil AsyncImage 프로필 이미지 지원

## Changes
| 파일 | 변경 |
|------|------|
| `model/user/User.kt` | NEW - 유저 도메인 모델 |
| `domain/user/UserRepository.kt` | NEW - Repository 인터페이스 |
| `core/data-api/user/*` | NEW - DTO, RemoteDataSource 인터페이스 |
| `core/data-remote/user/*` | NEW - Ktor API 구현체 |
| `core/data/user/UserRepositoryImpl.kt` | NEW - 로컬 캐시 우선 전략 |
| `DataStoreKey.kt` | MOD - USER_ID, USER_NICKNAME, USER_PROFILE_IMAGE_URL 추가 |
| `LatestBookmark(Response).kt` | MOD - bookTitle 필드 추가 |
| `DI Modules` | MOD - UserRemoteDataSource, UserRepository 등록 |
| `Settings Feature` | MOD - State, SideEffect, ViewModel, Screen 전면 수정 |

## Test plan
- [ ] 설정 화면 진입 시 API에서 닉네임/프로필 이미지 정상 로드 확인
- [ ] 프로필 이미지 없는 유저 → 기본 ic_person 아이콘 표시 확인
- [ ] 캐시된 유저 정보로 즉시 표시 후 API 미호출 확인
- [ ] LatestBookmark 카드에 인용문 1줄 + "책제목 · 날짜" 표시 확인
- [ ] "전체 보기" 버튼 클릭 시 NavigateToAllBookmarks SideEffect 발생 확인
- [ ] 빌드 성공 (`assembleDebug`, `ktlintCheck`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)