### PR TITLE
#44 : 이미지 크롭/OCR + 책갈피 저장 API 연동

### DIFF
--- a/core/common/build.gradle.kts
+++ b/core/common/build.gradle.kts
@@ -28,6 +28,7 @@ kotlin {
     sourceSets {
         commonMain.dependencies {
             implementation(libs.kotlinx.coroutines)
+            implementation(libs.kotlinx.datetime)
         }
     }
 }

--- a/core/common/src/commonMain/kotlin/com/phase/bookpin/common/extensions/DateExt.kt
+++ b/core/common/src/commonMain/kotlin/com/phase/bookpin/common/extensions/DateExt.kt
@@ -1,0 +1,8 @@
+package com.phase.bookpin.common.extensions
+
+import kotlinx.datetime.LocalDateTime
+
+fun String.toFormattedDate(): String = runCatching {
+    val dateTime = LocalDateTime.parse(this)
+    "${dateTime.year}년 ${dateTime.monthNumber}월 ${dateTime.dayOfMonth}일"
+}.getOrDefault(this)

--- a/core/data-api/src/commonMain/kotlin/com/phase/bookpin/data/api/book/BookRemoteDataSource.kt
+++ b/core/data-api/src/commonMain/kotlin/com/phase/bookpin/data/api/book/BookRemoteDataSource.kt
@@ -10,4 +10,6 @@ interface BookRemoteDataSource {
     suspend fun getTextBookmarks(bookId: Long): Result<List<BookmarkResponse>>
 
     suspend fun getPhotoBookmarks(bookId: Long): Result<List<BookmarkResponse>>
+
+    suspend fun createBookmark(bookId: Long, request: CreateBookmarkRequest): Result<BookmarkResponse>
 }

--- a/core/data-api/src/commonMain/kotlin/com/phase/bookpin/data/api/book/CreateBookmarkRequest.kt
+++ b/core/data-api/src/commonMain/kotlin/com/phase/bookpin/data/api/book/CreateBookmarkRequest.kt
@@ -1,0 +1,11 @@
+package com.phase.bookpin.data.api.book
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class CreateBookmarkRequest(
+    val pageNumber: Int,
+    val extractedText: String,
+    val note: String,
+    val imageUrl: String,
+)

--- a/core/data-api/src/commonMain/kotlin/com/phase/bookpin/data/api/image/ImageRemoteDataSource.kt
+++ b/core/data-api/src/commonMain/kotlin/com/phase/bookpin/data/api/image/ImageRemoteDataSource.kt
@@ -1,0 +1,5 @@
+package com.phase.bookpin.data.api.image
+
+interface ImageRemoteDataSource {
+    suspend fun getPresignedUrl(imageExtension: String): Result<PresignedUrlResponse>
+}

--- a/core/data-api/src/commonMain/kotlin/com/phase/bookpin/data/api/image/ImageRemoteDataSource.kt
+++ b/core/data-api/src/commonMain/kotlin/com/phase/bookpin/data/api/image/ImageRemoteDataSource.kt
@@ -2,4 +2,6 @@ package com.phase.bookpin.data.api.image
 
 interface ImageRemoteDataSource {
     suspend fun getPresignedUrl(imageExtension: String): Result<PresignedUrlResponse>
+
+    suspend fun uploadImage(presignedUrl: String, imageBytes: ByteArray, contentType: String): Result<Unit>
 }

--- a/core/data-api/src/commonMain/kotlin/com/phase/bookpin/data/api/image/PresignedUrlResponse.kt
+++ b/core/data-api/src/commonMain/kotlin/com/phase/bookpin/data/api/image/PresignedUrlResponse.kt
@@ -1,0 +1,9 @@
+package com.phase.bookpin.data.api.image
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class PresignedUrlResponse(
+    val url: String,
+    val imageUrl: String,
+)

--- a/core/data-remote/build.gradle.kts
+++ b/core/data-remote/build.gradle.kts
@@ -21,7 +21,7 @@ buildkonfig {
     defaultConfigs {
         buildConfigField(BOOLEAN, "IS_DEBUG", "true")
         buildConfigField(STRING, "BASE_URL", localProperties.getProperty("BASE_URL", "https://api.bookpin.com/"))
-        buildConfigField(STRING, "AMAZON_S3", "s3.ap-northeast-2.amazonaws.com/")
+        buildConfigField(STRING, "AMAZON_S3", "s3.ap-northeast-2.amazonaws.com")
     }
 
     defaultConfigs("release") {

--- a/core/data-remote/src/commonMain/kotlin/com/phase/bookpin/data/remote/book/BookRemoteDataSourceImpl.kt
+++ b/core/data-remote/src/commonMain/kotlin/com/phase/bookpin/data/remote/book/BookRemoteDataSourceImpl.kt
@@ -4,9 +4,11 @@ import com.phase.bookpin.data.api.book.BookDetailResponse
 import com.phase.bookpin.data.api.book.BookItemResponse
 import com.phase.bookpin.data.api.book.BookRemoteDataSource
 import com.phase.bookpin.data.api.book.BookmarkResponse
+import com.phase.bookpin.data.api.book.CreateBookmarkRequest
 import com.phase.bookpin.data.api.book.LatestBookmarkResponse
 import com.phase.bookpin.data.remote.client.safeRequest
 import io.ktor.client.HttpClient
+import io.ktor.client.request.setBody
 import io.ktor.http.HttpMethod
 import io.ktor.http.path
 
@@ -51,5 +53,17 @@ class BookRemoteDataSourceImpl(
                 method = HttpMethod.Get
                 path("api/v1/books/$bookId/bookmarks/photo")
             }
+        }
+
+    override suspend fun createBookmark(
+        bookId: Long,
+        request: CreateBookmarkRequest,
+    ): Result<BookmarkResponse> =
+        httpClient.safeRequest {
+            url {
+                method = HttpMethod.Post
+                path("api/v1/books/$bookId/bookmarks")
+            }
+            setBody(request)
         }
 }

--- a/core/data-remote/src/commonMain/kotlin/com/phase/bookpin/data/remote/di/DataRemoteModule.kt
+++ b/core/data-remote/src/commonMain/kotlin/com/phase/bookpin/data/remote/di/DataRemoteModule.kt
@@ -2,9 +2,11 @@ package com.phase.bookpin.data.remote.di
 
 import com.phase.bookpin.data.api.auth.AuthRemoteDataSource
 import com.phase.bookpin.data.api.book.BookRemoteDataSource
+import com.phase.bookpin.data.api.image.ImageRemoteDataSource
 import com.phase.bookpin.data.api.search.SearchRemoteDataSource
 import com.phase.bookpin.data.remote.auth.AuthRemoteDataSourceImpl
 import com.phase.bookpin.data.remote.book.BookRemoteDataSourceImpl
+import com.phase.bookpin.data.remote.image.ImageRemoteDataSourceImpl
 import com.phase.bookpin.data.remote.search.SearchRemoteDataSourceImpl
 import com.phase.bookpin.data.remote.client.createHttpClient
 import com.phase.bookpin.data.remote.client.createRefreshHttpClient
@@ -33,5 +35,8 @@ val dataRemoteModule = module {
     }
     single<SearchRemoteDataSource> {
         SearchRemoteDataSourceImpl(httpClient = get())
+    }
+    single<ImageRemoteDataSource> {
+        ImageRemoteDataSourceImpl(httpClient = get())
     }
 }

--- a/core/data-remote/src/commonMain/kotlin/com/phase/bookpin/data/remote/image/ImageRemoteDataSourceImpl.kt
+++ b/core/data-remote/src/commonMain/kotlin/com/phase/bookpin/data/remote/image/ImageRemoteDataSourceImpl.kt
@@ -1,0 +1,21 @@
+package com.phase.bookpin.data.remote.image
+
+import com.phase.bookpin.data.api.image.ImageRemoteDataSource
+import com.phase.bookpin.data.api.image.PresignedUrlResponse
+import com.phase.bookpin.data.remote.client.safeRequest
+import io.ktor.client.HttpClient
+import io.ktor.http.HttpMethod
+import io.ktor.http.path
+
+class ImageRemoteDataSourceImpl(
+    private val httpClient: HttpClient,
+) : ImageRemoteDataSource {
+    override suspend fun getPresignedUrl(imageExtension: String): Result<PresignedUrlResponse> =
+        httpClient.safeRequest {
+            url {
+                method = HttpMethod.Get
+                path("api/v1/image/presigned-url")
+                parameters.append("imageExtension", imageExtension)
+            }
+        }
+}

--- a/core/data-remote/src/commonMain/kotlin/com/phase/bookpin/data/remote/image/ImageRemoteDataSourceImpl.kt
+++ b/core/data-remote/src/commonMain/kotlin/com/phase/bookpin/data/remote/image/ImageRemoteDataSourceImpl.kt
@@ -4,7 +4,11 @@ import com.phase.bookpin.data.api.image.ImageRemoteDataSource
 import com.phase.bookpin.data.api.image.PresignedUrlResponse
 import com.phase.bookpin.data.remote.client.safeRequest
 import io.ktor.client.HttpClient
+import io.ktor.client.request.setBody
+import io.ktor.client.request.url
+import io.ktor.http.ContentType
 import io.ktor.http.HttpMethod
+import io.ktor.http.contentType
 import io.ktor.http.path
 
 class ImageRemoteDataSourceImpl(
@@ -18,4 +22,17 @@ class ImageRemoteDataSourceImpl(
                 parameters.append("imageExtension", imageExtension)
             }
         }
+
+    override suspend fun uploadImage(
+        presignedUrl: String,
+        imageBytes: ByteArray,
+        contentType: String,
+    ): Result<Unit> = runCatching {
+        httpClient.safeRequest<String> {
+            method = HttpMethod.Put
+            url(presignedUrl)
+            contentType(ContentType.parse(contentType))
+            setBody(imageBytes)
+        }.getOrThrow()
+    }
 }

--- a/core/data/src/commonMain/kotlin/com/phase/bookpin/data/book/BookRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/com/phase/bookpin/data/book/BookRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package com.phase.bookpin.data.book
 
 import com.phase.bookpin.data.api.book.BookRemoteDataSource
+import com.phase.bookpin.data.api.book.CreateBookmarkRequest
 import com.phase.bookpin.domain.book.BookRepository
 import com.phase.bookpin.model.book.BookDetail
 import com.phase.bookpin.model.book.BookItem
@@ -34,5 +35,21 @@ class BookRepositoryImpl(
         return dataSource.getPhotoBookmarks(bookId).mapCatching { responses ->
             responses.map { it.toBookmark() }
         }
+    }
+
+    override suspend fun createBookmark(
+        bookId: Long,
+        pageNumber: Int,
+        extractedText: String,
+        note: String,
+        imageUrl: String,
+    ): Result<Bookmark> {
+        val request = CreateBookmarkRequest(
+            pageNumber = pageNumber,
+            extractedText = extractedText,
+            note = note,
+            imageUrl = imageUrl,
+        )
+        return dataSource.createBookmark(bookId, request).mapCatching { it.toBookmark() }
     }
 }

--- a/core/data/src/commonMain/kotlin/com/phase/bookpin/data/di/DataModule.kt
+++ b/core/data/src/commonMain/kotlin/com/phase/bookpin/data/di/DataModule.kt
@@ -5,11 +5,13 @@ import com.phase.bookpin.data.auth.AuthRepositoryImpl
 import com.phase.bookpin.data.auth.SessionRepositoryImpl
 import com.phase.bookpin.data.book.BookRepositoryImpl
 import com.phase.bookpin.data.device.DeviceRepositoryImpl
+import com.phase.bookpin.data.image.ImageRepositoryImpl
 import com.phase.bookpin.data.search.SearchRepositoryImpl
 import com.phase.bookpin.domain.auth.AuthRepository
 import com.phase.bookpin.domain.auth.SessionRepository
 import com.phase.bookpin.domain.book.BookRepository
 import com.phase.bookpin.domain.device.DeviceRepository
+import com.phase.bookpin.domain.image.ImageRepository
 import com.phase.bookpin.domain.search.SearchRepository
 import org.koin.core.module.dsl.bind
 import org.koin.core.module.dsl.singleOf
@@ -23,5 +25,6 @@ val dataModule = module {
     }
     singleOf(::DeviceRepositoryImpl) { bind<DeviceRepository>() }
     singleOf(::BookRepositoryImpl) { bind<BookRepository>() }
+    singleOf(::ImageRepositoryImpl) { bind<ImageRepository>() }
     singleOf(::SearchRepositoryImpl) { bind<SearchRepository>() }
 }

--- a/core/data/src/commonMain/kotlin/com/phase/bookpin/data/image/ImageRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/com/phase/bookpin/data/image/ImageRepositoryImpl.kt
@@ -1,0 +1,11 @@
+package com.phase.bookpin.data.image
+
+import com.phase.bookpin.data.api.image.ImageRemoteDataSource
+import com.phase.bookpin.domain.image.ImageRepository
+
+class ImageRepositoryImpl(
+    private val dataSource: ImageRemoteDataSource,
+) : ImageRepository {
+    override suspend fun getImageUrl(imageExtension: String): Result<String> =
+        dataSource.getPresignedUrl(imageExtension).mapCatching { it.imageUrl }
+}

--- a/core/data/src/commonMain/kotlin/com/phase/bookpin/data/image/ImageRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/com/phase/bookpin/data/image/ImageRepositoryImpl.kt
@@ -6,6 +6,13 @@ import com.phase.bookpin.domain.image.ImageRepository
 class ImageRepositoryImpl(
     private val dataSource: ImageRemoteDataSource,
 ) : ImageRepository {
-    override suspend fun getImageUrl(imageExtension: String): Result<String> =
-        dataSource.getPresignedUrl(imageExtension).mapCatching { it.imageUrl }
+    override suspend fun uploadImage(imageBytes: ByteArray, imageExtension: String): Result<String> =
+        dataSource.getPresignedUrl(imageExtension).mapCatching { response ->
+            dataSource.uploadImage(
+                presignedUrl = response.url,
+                imageBytes = imageBytes,
+                contentType = "image/$imageExtension",
+            ).getOrThrow()
+            response.imageUrl
+        }
 }

--- a/domain/src/commonMain/kotlin/com/phase/bookpin/domain/book/BookRepository.kt
+++ b/domain/src/commonMain/kotlin/com/phase/bookpin/domain/book/BookRepository.kt
@@ -15,4 +15,12 @@ interface BookRepository {
     suspend fun getTextBookmarks(bookId: Long): Result<List<Bookmark>>
 
     suspend fun getPhotoBookmarks(bookId: Long): Result<List<Bookmark>>
+
+    suspend fun createBookmark(
+        bookId: Long,
+        pageNumber: Int,
+        extractedText: String,
+        note: String,
+        imageUrl: String,
+    ): Result<Bookmark>
 }

--- a/domain/src/commonMain/kotlin/com/phase/bookpin/domain/image/ImageRepository.kt
+++ b/domain/src/commonMain/kotlin/com/phase/bookpin/domain/image/ImageRepository.kt
@@ -1,5 +1,5 @@
 package com.phase.bookpin.domain.image
 
 interface ImageRepository {
-    suspend fun getImageUrl(imageExtension: String): Result<String>
+    suspend fun uploadImage(imageBytes: ByteArray, imageExtension: String): Result<String>
 }

--- a/domain/src/commonMain/kotlin/com/phase/bookpin/domain/image/ImageRepository.kt
+++ b/domain/src/commonMain/kotlin/com/phase/bookpin/domain/image/ImageRepository.kt
@@ -1,0 +1,5 @@
+package com.phase.bookpin.domain.image
+
+interface ImageRepository {
+    suspend fun getImageUrl(imageExtension: String): Result<String>
+}

--- a/feature/bookmark/src/androidMain/kotlin/com/phase/bookpin/bookmark/add/ImageFileReader.android.kt
+++ b/feature/bookmark/src/androidMain/kotlin/com/phase/bookpin/bookmark/add/ImageFileReader.android.kt
@@ -1,0 +1,15 @@
+package com.phase.bookpin.bookmark.add
+
+import android.content.Context
+import android.net.Uri
+import android.webkit.MimeTypeMap
+
+actual class ImageFileReader(
+    private val context: Context,
+) {
+    actual fun getExtension(uri: String): String {
+        val contentUri = Uri.parse(uri)
+        val mimeType = context.contentResolver.getType(contentUri)
+        return MimeTypeMap.getSingleton().getExtensionFromMimeType(mimeType) ?: "jpg"
+    }
+}

--- a/feature/bookmark/src/androidMain/kotlin/com/phase/bookpin/bookmark/add/ImageFileReader.android.kt
+++ b/feature/bookmark/src/androidMain/kotlin/com/phase/bookpin/bookmark/add/ImageFileReader.android.kt
@@ -7,6 +7,12 @@ import android.webkit.MimeTypeMap
 actual class ImageFileReader(
     private val context: Context,
 ) {
+    actual suspend fun readBytes(uri: String): ByteArray {
+        val inputStream = context.contentResolver.openInputStream(Uri.parse(uri))
+            ?: throw IllegalStateException("Cannot open input stream for uri: $uri")
+        return inputStream.use { it.readBytes() }
+    }
+
     actual fun getExtension(uri: String): String {
         val contentUri = Uri.parse(uri)
         val mimeType = context.contentResolver.getType(contentUri)

--- a/feature/bookmark/src/androidMain/kotlin/com/phase/bookpin/bookmark/di/BookmarkPlatformModule.android.kt
+++ b/feature/bookmark/src/androidMain/kotlin/com/phase/bookpin/bookmark/di/BookmarkPlatformModule.android.kt
@@ -1,5 +1,6 @@
 package com.phase.bookpin.bookmark.di
 
+import com.phase.bookpin.bookmark.add.ImageFileReader
 import com.phase.bookpin.bookmark.add.TextRecognizer
 import org.koin.android.ext.koin.androidContext
 import org.koin.core.module.Module
@@ -7,4 +8,5 @@ import org.koin.dsl.module
 
 actual val bookmarkPlatformModule: Module = module {
     single { TextRecognizer(androidContext()) }
+    single { ImageFileReader(androidContext()) }
 }

--- a/feature/bookmark/src/commonMain/composeResources/values/strings.xml
+++ b/feature/bookmark/src/commonMain/composeResources/values/strings.xml
@@ -19,7 +19,8 @@
     <string name="bookmark_content_label">책갈피 내용</string>
     <string name="bookmark_extracted_text_placeholder">책갈피 내용을 입력하거나 수정하세요...</string>
     <string name="bookmark_page_number">페이지 번호</string>
-    <string name="bookmark_page_placeholder">선택사항</string>
+    <string name="bookmark_page_placeholder">페이지 번호를 입력하세요</string>
+    <string name="bookmark_page_required">페이지 번호를 입력해주세요.</string>
     <string name="bookmark_personal_memo">개인 메모</string>
     <string name="bookmark_memo_placeholder">생각을 기록하세요 (선택사항)</string>
     <string name="bookmark_save">책갈피 저장</string>

--- a/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/add/AddBookmarkScreen.kt
+++ b/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/add/AddBookmarkScreen.kt
@@ -188,6 +188,7 @@ fun AddBookmarkScreen(
 
                 Button(
                     onClick = viewModel::onSaveBookmark,
+                    enabled = state.isSaveEnabled,
                     modifier = Modifier
                         .fillMaxWidth()
                         .height(52.dp),
@@ -195,6 +196,8 @@ fun AddBookmarkScreen(
                     colors = ButtonDefaults.buttonColors(
                         containerColor = BookPinTheme.colors.buttonPrimary,
                         contentColor = BookPinTheme.colors.textOnAccent,
+                        disabledContainerColor = BookPinTheme.colors.bgMuted,
+                        disabledContentColor = BookPinTheme.colors.textPlaceholder,
                     ),
                 ) {
                     Icon(

--- a/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/add/AddBookmarkScreen.kt
+++ b/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/add/AddBookmarkScreen.kt
@@ -69,8 +69,8 @@ fun AddBookmarkScreen(
         }
     }
 
-    LaunchedEffect(bookmarkType) {
-        viewModel.initBookmarkType(bookmarkType)
+    LaunchedEffect(bookId, bookmarkType) {
+        viewModel.init(bookId, bookmarkType)
         launchPicker(bookmarkType)
     }
 

--- a/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/add/AddBookmarkScreen.kt
+++ b/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/add/AddBookmarkScreen.kt
@@ -28,6 +28,7 @@ import coil3.compose.AsyncImage
 import com.phase.bookpin.common.extensions.collectSideEffect
 import com.phase.bookpin.common.snackbar.LocalSnackbarHost
 import com.phase.bookpin.designsystem.BookPinTheme
+import com.phase.bookpin.designsystem.component.BPLoadingScreen
 import com.phase.bookpin.designsystem.component.BPTextArea
 import com.phase.bookpin.designsystem.component.BPTopBar
 import com.phase.bookpin.model.bookmark.BookmarkType
@@ -84,132 +85,138 @@ fun AddBookmarkScreen(
         }
     }
 
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .background(BookPinTheme.colors.bgCanvas),
-    ) {
-        BPTopBar(
-            title = stringResource(Res.string.bookmark_add_title),
-            onClose = viewModel::onCloseClick,
-        )
-
+    Box(modifier = Modifier.fillMaxSize()) {
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .verticalScroll(rememberScrollState())
-                .padding(horizontal = 24.dp)
-                .padding(top = 24.dp, bottom = 32.dp),
+                .background(BookPinTheme.colors.bgCanvas),
         ) {
-            if (state.bookmarkType != BookmarkType.TEXT) {
-                PhotoSection(
-                    photoUri = state.photoUri,
-                    onRetakeClick = { launchPicker(state.bookmarkType) },
-                )
-                Spacer(modifier = Modifier.height(24.dp))
-            }
-
-            Text(
-                text = if (state.bookmarkType != BookmarkType.TEXT) {
-                    stringResource(Res.string.bookmark_extracted_text)
-                } else {
-                    stringResource(Res.string.bookmark_content_label)
-                },
-                style = BookPinTheme.typography.titleSmall,
-                color = BookPinTheme.colors.textPrimary,
+            BPTopBar(
+                title = stringResource(Res.string.bookmark_add_title),
+                onClose = viewModel::onCloseClick,
             )
 
-            Spacer(modifier = Modifier.height(8.dp))
-
-            Box {
-                BPTextArea(
-                    value = state.extractedText,
-                    onValueChange = viewModel::onExtractedTextChanged,
-                    placeholder = stringResource(Res.string.bookmark_extracted_text_placeholder),
-                    minHeight = 172.dp,
-                )
-                if (state.isOcrProcessing) {
-                    Box(
-                        modifier = Modifier
-                            .matchParentSize()
-                            .background(
-                                BookPinTheme.colors.bgSurface.copy(alpha = 0.6f),
-                                RoundedCornerShape(12.dp),
-                            ),
-                        contentAlignment = Alignment.Center,
-                    ) {
-                        CircularProgressIndicator(
-                            color = BookPinTheme.colors.buttonPrimary,
-                            modifier = Modifier.size(36.dp),
-                        )
-                    }
-                }
-            }
-
-            Spacer(modifier = Modifier.height(20.dp))
-
-            Text(
-                text = stringResource(Res.string.bookmark_page_number),
-                style = BookPinTheme.typography.titleSmall,
-                color = BookPinTheme.colors.textPrimary,
-            )
-
-            Spacer(modifier = Modifier.height(8.dp))
-
-            BPTextArea(
-                value = state.pageNumber,
-                onValueChange = viewModel::onPageNumberChanged,
-                placeholder = stringResource(Res.string.bookmark_page_placeholder),
-                minHeight = 48.dp,
-                modifier = Modifier.fillMaxWidth(0.5f),
-                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-            )
-
-            Spacer(modifier = Modifier.height(20.dp))
-
-            Text(
-                text = stringResource(Res.string.bookmark_personal_memo),
-                style = BookPinTheme.typography.titleSmall,
-                color = BookPinTheme.colors.textPrimary,
-            )
-
-            Spacer(modifier = Modifier.height(8.dp))
-
-            BPTextArea(
-                value = state.personalMemo,
-                onValueChange = viewModel::onPersonalMemoChanged,
-                placeholder = stringResource(Res.string.bookmark_memo_placeholder),
-                minHeight = 100.dp,
-            )
-
-            Spacer(modifier = Modifier.height(32.dp))
-
-            Button(
-                onClick = viewModel::onSaveBookmark,
+            Column(
                 modifier = Modifier
-                    .fillMaxWidth()
-                    .height(52.dp),
-                shape = RoundedCornerShape(26.dp),
-                colors = ButtonDefaults.buttonColors(
-                    containerColor = BookPinTheme.colors.buttonPrimary,
-                    contentColor = BookPinTheme.colors.textOnAccent,
-                ),
+                    .fillMaxSize()
+                    .verticalScroll(rememberScrollState())
+                    .padding(horizontal = 24.dp)
+                    .padding(top = 24.dp, bottom = 32.dp),
             ) {
-                Icon(
-                    painter = painterResource(Res.drawable.ic_check),
-                    contentDescription = null,
-                    modifier = Modifier.size(20.dp),
-                    tint = BookPinTheme.colors.textOnAccent,
-                )
-
-                Spacer(modifier = Modifier.width(8.dp))
+                if (state.bookmarkType != BookmarkType.TEXT) {
+                    PhotoSection(
+                        photoUri = state.photoUri,
+                        onRetakeClick = { launchPicker(state.bookmarkType) },
+                    )
+                    Spacer(modifier = Modifier.height(24.dp))
+                }
 
                 Text(
-                    text = stringResource(Res.string.bookmark_save),
-                    style = BookPinTheme.typography.titleMedium,
-                    color = BookPinTheme.colors.textOnAccent,
+                    text = if (state.bookmarkType != BookmarkType.TEXT) {
+                        stringResource(Res.string.bookmark_extracted_text)
+                    } else {
+                        stringResource(Res.string.bookmark_content_label)
+                    },
+                    style = BookPinTheme.typography.titleSmall,
+                    color = BookPinTheme.colors.textPrimary,
                 )
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                Box {
+                    BPTextArea(
+                        value = state.extractedText,
+                        onValueChange = viewModel::onExtractedTextChanged,
+                        placeholder = stringResource(Res.string.bookmark_extracted_text_placeholder),
+                        minHeight = 172.dp,
+                    )
+                    if (state.isOcrProcessing) {
+                        Box(
+                            modifier = Modifier
+                                .matchParentSize()
+                                .background(
+                                    BookPinTheme.colors.bgSurface.copy(alpha = 0.6f),
+                                    RoundedCornerShape(12.dp),
+                                ),
+                            contentAlignment = Alignment.Center,
+                        ) {
+                            CircularProgressIndicator(
+                                color = BookPinTheme.colors.buttonPrimary,
+                                modifier = Modifier.size(36.dp),
+                            )
+                        }
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(20.dp))
+
+                Text(
+                    text = stringResource(Res.string.bookmark_page_number),
+                    style = BookPinTheme.typography.titleSmall,
+                    color = BookPinTheme.colors.textPrimary,
+                )
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                BPTextArea(
+                    value = state.pageNumber,
+                    onValueChange = viewModel::onPageNumberChanged,
+                    placeholder = stringResource(Res.string.bookmark_page_placeholder),
+                    minHeight = 48.dp,
+                    modifier = Modifier.fillMaxWidth(0.5f),
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                )
+
+                Spacer(modifier = Modifier.height(20.dp))
+
+                Text(
+                    text = stringResource(Res.string.bookmark_personal_memo),
+                    style = BookPinTheme.typography.titleSmall,
+                    color = BookPinTheme.colors.textPrimary,
+                )
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                BPTextArea(
+                    value = state.personalMemo,
+                    onValueChange = viewModel::onPersonalMemoChanged,
+                    placeholder = stringResource(Res.string.bookmark_memo_placeholder),
+                    minHeight = 100.dp,
+                )
+
+                Spacer(modifier = Modifier.height(32.dp))
+
+                Button(
+                    onClick = viewModel::onSaveBookmark,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(52.dp),
+                    shape = RoundedCornerShape(26.dp),
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = BookPinTheme.colors.buttonPrimary,
+                        contentColor = BookPinTheme.colors.textOnAccent,
+                    ),
+                ) {
+                    Icon(
+                        painter = painterResource(Res.drawable.ic_check),
+                        contentDescription = null,
+                        modifier = Modifier.size(20.dp),
+                        tint = BookPinTheme.colors.textOnAccent,
+                    )
+
+                    Spacer(modifier = Modifier.width(8.dp))
+
+                    Text(
+                        text = stringResource(Res.string.bookmark_save),
+                        style = BookPinTheme.typography.titleMedium,
+                        color = BookPinTheme.colors.textOnAccent,
+                    )
+                }
             }
+        }
+
+        if (state.isLoading) {
+            BPLoadingScreen()
         }
     }
 }

--- a/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/add/AddBookmarkState.kt
+++ b/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/add/AddBookmarkState.kt
@@ -10,4 +10,6 @@ data class AddBookmarkState(
     val personalMemo: String = "",
     val isLoading: Boolean = false,
     val isOcrProcessing: Boolean = false,
-)
+) {
+    val isSaveEnabled: Boolean get() = pageNumber.toIntOrNull() != null
+}

--- a/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/add/AddBookmarkViewModel.kt
+++ b/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/add/AddBookmarkViewModel.kt
@@ -2,16 +2,24 @@ package com.phase.bookpin.bookmark.add
 
 import androidx.lifecycle.viewModelScope
 import com.phase.bookpin.common.BaseViewModel
+import com.phase.bookpin.domain.book.BookRepository
+import com.phase.bookpin.domain.image.ImageRepository
 import com.phase.bookpin.model.bookmark.BookmarkType
 import kotlinx.coroutines.launch
 
 class AddBookmarkViewModel(
     private val textRecognizer: TextRecognizer,
+    private val bookRepository: BookRepository,
+    private val imageRepository: ImageRepository,
+    private val imageFileReader: ImageFileReader,
 ) : BaseViewModel<AddBookmarkState, AddBookmarkSideEffect>() {
     override fun createInitialState(): AddBookmarkState = AddBookmarkState()
 
-    fun initBookmarkType(type: BookmarkType) {
-        reduce { copy(bookmarkType = type) }
+    private var bookId: Long = 0L
+
+    fun init(bookId: Long, bookmarkType: BookmarkType) {
+        this.bookId = bookId
+        reduce { copy(bookmarkType = bookmarkType) }
     }
 
     fun onExtractedTextChanged(text: String) {
@@ -27,8 +35,51 @@ class AddBookmarkViewModel(
     }
 
     fun onSaveBookmark() {
-        // TODO: API 연동 후 구현
-        postSideEffect(AddBookmarkSideEffect.BookmarkSaved)
+        val state = uiState.value
+        if (state.isLoading) return
+
+        viewModelScope.launch {
+            reduce { copy(isLoading = true) }
+
+            val imageUrlResult = if (state.bookmarkType != BookmarkType.TEXT && state.photoUri != null) {
+                val extension = imageFileReader.getExtension(state.photoUri)
+                imageRepository.getImageUrl(extension)
+            } else {
+                Result.success("")
+            }
+
+            imageUrlResult.onFailure { error ->
+                reduce { copy(isLoading = false) }
+                postSideEffect(
+                    AddBookmarkSideEffect.ShowSnackbar(
+                        error.message ?: "이미지 URL 발급에 실패했습니다.",
+                    ),
+                )
+                return@launch
+            }
+
+            val imageUrl = imageUrlResult.getOrThrow()
+            val pageNumber = state.pageNumber.toIntOrNull() ?: 0
+
+            bookRepository
+                .createBookmark(
+                    bookId = bookId,
+                    pageNumber = pageNumber,
+                    extractedText = state.extractedText,
+                    note = state.personalMemo,
+                    imageUrl = imageUrl,
+                ).onSuccess {
+                    reduce { copy(isLoading = false) }
+                    postSideEffect(AddBookmarkSideEffect.BookmarkSaved)
+                }.onFailure { error ->
+                    reduce { copy(isLoading = false) }
+                    postSideEffect(
+                        AddBookmarkSideEffect.ShowSnackbar(
+                            error.message ?: "책갈피 저장에 실패했습니다.",
+                        ),
+                    )
+                }
+        }
     }
 
     fun onPhotoUriChanged(uri: String?) {

--- a/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/add/AddBookmarkViewModel.kt
+++ b/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/add/AddBookmarkViewModel.kt
@@ -38,6 +38,12 @@ class AddBookmarkViewModel(
         val state = uiState.value
         if (state.isLoading) return
 
+        val pageNumber = state.pageNumber.toIntOrNull()
+        if (pageNumber == null) {
+            postSideEffect(AddBookmarkSideEffect.ShowSnackbar("페이지 번호를 입력해주세요."))
+            return
+        }
+
         viewModelScope.launch {
             reduce { copy(isLoading = true) }
 
@@ -62,7 +68,6 @@ class AddBookmarkViewModel(
             }
 
             val imageUrl = imageUrlResult.getOrThrow()
-            val pageNumber = state.pageNumber.toIntOrNull() ?: 0
 
             bookRepository
                 .createBookmark(

--- a/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/add/AddBookmarkViewModel.kt
+++ b/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/add/AddBookmarkViewModel.kt
@@ -42,8 +42,11 @@ class AddBookmarkViewModel(
             reduce { copy(isLoading = true) }
 
             val imageUrlResult = if (state.bookmarkType != BookmarkType.TEXT && state.photoUri != null) {
-                val extension = imageFileReader.getExtension(state.photoUri)
-                imageRepository.getImageUrl(extension)
+                runCatching {
+                    val extension = imageFileReader.getExtension(state.photoUri)
+                    val bytes = imageFileReader.readBytes(state.photoUri)
+                    imageRepository.uploadImage(bytes, extension).getOrThrow()
+                }
             } else {
                 Result.success("")
             }
@@ -52,7 +55,7 @@ class AddBookmarkViewModel(
                 reduce { copy(isLoading = false) }
                 postSideEffect(
                     AddBookmarkSideEffect.ShowSnackbar(
-                        error.message ?: "이미지 URL 발급에 실패했습니다.",
+                        error.message ?: "이미지 업로드에 실패했습니다.",
                     ),
                 )
                 return@launch

--- a/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/add/ImageFileReader.kt
+++ b/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/add/ImageFileReader.kt
@@ -1,5 +1,7 @@
 package com.phase.bookpin.bookmark.add
 
 expect class ImageFileReader {
+    suspend fun readBytes(uri: String): ByteArray
+
     fun getExtension(uri: String): String
 }

--- a/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/add/ImageFileReader.kt
+++ b/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/add/ImageFileReader.kt
@@ -1,0 +1,5 @@
+package com.phase.bookpin.bookmark.add
+
+expect class ImageFileReader {
+    fun getExtension(uri: String): String
+}

--- a/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/detail/BookDetailScreen.kt
+++ b/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/detail/BookDetailScreen.kt
@@ -106,7 +106,7 @@ fun BookDetailScreen(
                     BookDetailStats(
                         currentPage = state.book.currentPage,
                         totalPages = state.book.totalPage,
-                        progressPercent = (state.book.progress * 100).toInt(),
+                        progressPercent = state.book.progress.toInt(),
                         onMarkAsCompleteClick = viewModel::onMarkAsCompleteClick,
                     )
                 }

--- a/feature/bookmark/src/iosMain/kotlin/com/phase/bookpin/bookmark/add/ImageFileReader.ios.kt
+++ b/feature/bookmark/src/iosMain/kotlin/com/phase/bookpin/bookmark/add/ImageFileReader.ios.kt
@@ -1,6 +1,26 @@
 package com.phase.bookpin.bookmark.add
 
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.usePinned
+import platform.Foundation.NSData
+import platform.Foundation.NSURL
+import platform.Foundation.dataWithContentsOfURL
+import platform.posix.memcpy
+
 actual class ImageFileReader {
+    @OptIn(ExperimentalForeignApi::class)
+    actual suspend fun readBytes(uri: String): ByteArray {
+        val nsUrl = NSURL.fileURLWithPath(uri)
+        val data = NSData.dataWithContentsOfURL(nsUrl)
+            ?: throw IllegalStateException("Cannot read file at path: $uri")
+        return ByteArray(data.length.toInt()).apply {
+            usePinned { pinned ->
+                memcpy(pinned.addressOf(0), data.bytes, data.length)
+            }
+        }
+    }
+
     actual fun getExtension(uri: String): String =
         uri.substringAfterLast('.', "jpg").lowercase()
 }

--- a/feature/bookmark/src/iosMain/kotlin/com/phase/bookpin/bookmark/add/ImageFileReader.ios.kt
+++ b/feature/bookmark/src/iosMain/kotlin/com/phase/bookpin/bookmark/add/ImageFileReader.ios.kt
@@ -1,0 +1,6 @@
+package com.phase.bookpin.bookmark.add
+
+actual class ImageFileReader {
+    actual fun getExtension(uri: String): String =
+        uri.substringAfterLast('.', "jpg").lowercase()
+}

--- a/feature/bookmark/src/iosMain/kotlin/com/phase/bookpin/bookmark/di/BookmarkPlatformModule.ios.kt
+++ b/feature/bookmark/src/iosMain/kotlin/com/phase/bookpin/bookmark/di/BookmarkPlatformModule.ios.kt
@@ -1,9 +1,11 @@
 package com.phase.bookpin.bookmark.di
 
+import com.phase.bookpin.bookmark.add.ImageFileReader
 import com.phase.bookpin.bookmark.add.TextRecognizer
 import org.koin.core.module.Module
 import org.koin.dsl.module
 
 actual val bookmarkPlatformModule: Module = module {
     single { TextRecognizer() }
+    single { ImageFileReader() }
 }

--- a/feature/settings/src/commonMain/composeResources/drawable/ic_person.xml
+++ b/feature/settings/src/commonMain/composeResources/drawable/ic_person.xml
@@ -1,9 +1,20 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="24dp"
     android:height="24dp"
-    android:viewportWidth="24"
-    android:viewportHeight="24">
+    android:viewportWidth="28"
+    android:viewportHeight="28">
     <path
-        android:fillColor="#000000"
-        android:pathData="M12,12c2.21,0 4,-1.79 4,-4s-1.79,-4 -4,-4 -4,1.79 -4,4 1.79,4 4,4zM12,14c-2.67,0 -8,1.34 -8,4v2h16v-2c0,-2.66 -5.33,-4 -8,-4z"/>
+        android:pathData="M22.16,24.49V22.16C22.16,20.92 21.67,19.74 20.79,18.86C19.92,17.99 18.73,17.49 17.49,17.49H10.5C9.26,17.49 8.07,17.99 7.2,18.86C6.32,19.74 5.83,20.92 5.83,22.16V24.49"
+        android:strokeWidth="2.33"
+        android:fillColor="#00000000"
+        android:strokeColor="#000000"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round" />
+    <path
+        android:pathData="M14,12.83C16.57,12.83 18.66,10.74 18.66,8.16C18.66,5.59 16.57,3.5 14,3.5C11.42,3.5 9.33,5.59 9.33,8.16C9.33,10.74 11.42,12.83 14,12.83Z"
+        android:strokeWidth="2.33"
+        android:fillColor="#00000000"
+        android:strokeColor="#000000"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round" />
 </vector>

--- a/feature/settings/src/commonMain/kotlin/com/phase/bookpin/settings/SettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/com/phase/bookpin/settings/SettingsScreen.kt
@@ -185,6 +185,8 @@ private fun ProfileCard(
                     .size(56.dp)
                     .clip(CircleShape),
                 contentScale = ContentScale.Crop,
+                error = painterResource(Res.drawable.ic_person),
+                fallback = painterResource(Res.drawable.ic_person),
             )
         } else {
             Box(

--- a/feature/settings/src/commonMain/kotlin/com/phase/bookpin/settings/SettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/com/phase/bookpin/settings/SettingsScreen.kt
@@ -26,6 +26,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import bookpin.settings.generated.resources.*
 import coil3.compose.AsyncImage
 import com.phase.bookpin.common.extensions.collectSideEffect
+import com.phase.bookpin.common.extensions.toFormattedDate
 import com.phase.bookpin.common.snackbar.LocalSnackbarHost
 import com.phase.bookpin.designsystem.BookPinTheme
 import com.phase.bookpin.designsystem.component.BPConfirmDialog
@@ -221,12 +222,16 @@ private fun LatestBookmarkSection(
     onViewAllClick: () -> Unit,
 ) {
     Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(
+                color = BookPinTheme.colors.bgSurface,
+                shape = RoundedCornerShape(16.dp),
+            ).padding(16.dp),
         verticalArrangement = Arrangement.spacedBy(12.dp),
     ) {
         Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 4.dp),
+            modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically,
         ) {
@@ -255,16 +260,7 @@ private fun LatestBookmarkSection(
             }
         }
 
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .background(
-                    color = BookPinTheme.colors.bgSurface,
-                    shape = RoundedCornerShape(16.dp),
-                ).padding(16.dp),
-        ) {
-            LatestBookmarkCard(bookmark = bookmark)
-        }
+        LatestBookmarkCard(bookmark = bookmark)
     }
 }
 
@@ -306,7 +302,7 @@ private fun LatestBookmarkCard(
                     append(bookmark.bookTitle)
                     append(" \u00B7 ")
                 }
-                append(bookmark.createdAt)
+                append(bookmark.createdAt.toFormattedDate())
             }
             Text(
                 text = subtitle,

--- a/feature/settings/src/commonMain/kotlin/com/phase/bookpin/settings/SettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/com/phase/bookpin/settings/SettingsScreen.kt
@@ -187,7 +187,7 @@ private fun ProfileCard(
                 ),
             contentAlignment = Alignment.Center,
         ) {
-            if (profileImageUrl != null) {
+            if (!profileImageUrl.isNullOrEmpty()) {
                 AsyncImage(
                     model = profileImageUrl,
                     contentDescription = null,

--- a/feature/settings/src/commonMain/kotlin/com/phase/bookpin/settings/SettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/com/phase/bookpin/settings/SettingsScreen.kt
@@ -178,27 +178,25 @@ private fun ProfileCard(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(16.dp),
     ) {
-        if (profileImageUrl != null) {
-            AsyncImage(
-                model = profileImageUrl,
-                contentDescription = null,
-                modifier = Modifier
-                    .size(56.dp)
-                    .clip(CircleShape),
-                contentScale = ContentScale.Crop,
-                error = painterResource(Res.drawable.ic_person),
-                fallback = painterResource(Res.drawable.ic_person),
-            )
-        } else {
-            Box(
-                modifier = Modifier
-                    .size(56.dp)
-                    .background(
-                        color = BookPinTheme.colors.bgMuted,
-                        shape = CircleShape,
-                    ),
-                contentAlignment = Alignment.Center,
-            ) {
+        Box(
+            modifier = Modifier
+                .size(56.dp)
+                .background(
+                    color = BookPinTheme.colors.bgMuted,
+                    shape = CircleShape,
+                ),
+            contentAlignment = Alignment.Center,
+        ) {
+            if (profileImageUrl != null) {
+                AsyncImage(
+                    model = profileImageUrl,
+                    contentDescription = null,
+                    modifier = Modifier
+                        .size(56.dp)
+                        .clip(CircleShape),
+                    contentScale = ContentScale.Crop,
+                )
+            } else {
                 Icon(
                     painter = painterResource(Res.drawable.ic_person),
                     contentDescription = null,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -75,6 +75,7 @@ jetbrains-navigation3-ui = { module = "org.jetbrains.androidx.navigation3:naviga
 kotlin-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinx-serialization-json" }
 kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
+kotlinx-datetime = { group = "org.jetbrains.kotlinx", name = "kotlinx-datetime", version.ref = "kotlinx-datetime" }
 
 # Test
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }


### PR DESCRIPTION
## 1. 📄 관련된 이슈 및 소개
- 관련 이슈: closes #44
- 소개: 책갈피 추가 화면에서 이미지 크롭, OCR 텍스트 추출, TEXT/PHOTO 책갈피 저장 API 연동 기능을 구현합니다.

## 2. 🔥 변경된 점
- **이미지 크롭 기능 추가**: `ImageCropper` expect/actual 구현 (Android: android-image-cropper, iOS: stub)
- **OCR 텍스트 자동 추출**: `TextRecognizer` expect/actual 구현 (Android: ML Kit 한국어 텍스트 인식)
- **Presigned URL 발급 API 연동**: `GET /api/v1/image/presigned-url` → S3 presigned URL + 영구 imageUrl 발급
- **S3 이미지 업로드**: presigned URL로 이미지 바이너리 PUT 업로드 (`ImageRepository.uploadImage`)
- **책갈피 생성 API 연동**: `POST /api/v1/books/{bookId}/bookmarks` 호출
- **전체 Data Layer 구현**: `ImageRemoteDataSource`, `ImageRepository`, `BookRepository.createBookmark` 추가
- **Platform DI 구성**: `ImageFileReader`, `TextRecognizer` Koin 모듈 등록
- **AddBookmarkViewModel 구현**: TEXT(직접 생성) / PHOTO(presigned URL → S3 업로드 → 생성) 분기 처리
- **로딩/에러 상태 관리**: isLoading 중복 저장 방지, 실패 시 Snackbar 표시

## 3. ✅ 필수 체크 사항
- [x] 빌드 확인
- [ ] 테스트 확인
- [ ] 코드 리뷰 요청

## 4. 📸 작업물 사진 공유(선택)

## 5. 💡 알게된 혹은 궁금한 사항
- S3 PUT 요청 시 Bearer 토큰 제외 (`ClientModule`의 `!url.host.endsWith(AMAZON_S3)` 조건 활용)
- S3 PUT 응답이 빈 body이므로 `safeRequest<String>`으로 처리
- iOS의 ImageCropper, TextRecognizer는 stub 상태 (추후 구현 필요)