### PR TITLE
#61 : 완독 처리 API 연동 및 홈 화면 이동 구현

### DIFF
--- a/compose-app/src/commonMain/kotlin/com/phase/bookpin/navigation/BookPinNavHost.kt
+++ b/compose-app/src/commonMain/kotlin/com/phase/bookpin/navigation/BookPinNavHost.kt
@@ -81,6 +81,7 @@ fun BookPinNavHost(
                     bookId = route.bookId,
                     onNavigateBack = onNavigateBack,
                     onNavigateToAddBookmark = { onNavigateToBookmarkTypeSelect(route.bookId) },
+                    onNavigateToHome = onNavigateToHome,
                 )
             }
 

--- a/core/data-api/src/commonMain/kotlin/com/phase/bookpin/data/api/book/BookRemoteDataSource.kt
+++ b/core/data-api/src/commonMain/kotlin/com/phase/bookpin/data/api/book/BookRemoteDataSource.kt
@@ -12,4 +12,6 @@ interface BookRemoteDataSource {
     suspend fun getPhotoBookmarks(bookId: Long): Result<List<BookmarkResponse>>
 
     suspend fun createBookmark(bookId: Long, request: CreateBookmarkRequest): Result<BookmarkResponse>
+
+    suspend fun completeBook(bookId: Long): Result<BookDetailResponse>
 }

--- a/core/data-remote/src/commonMain/kotlin/com/phase/bookpin/data/remote/book/BookRemoteDataSourceImpl.kt
+++ b/core/data-remote/src/commonMain/kotlin/com/phase/bookpin/data/remote/book/BookRemoteDataSourceImpl.kt
@@ -66,4 +66,12 @@ class BookRemoteDataSourceImpl(
             }
             setBody(request)
         }
+
+    override suspend fun completeBook(bookId: Long): Result<BookDetailResponse> =
+        httpClient.safeRequest {
+            url {
+                method = HttpMethod.Post
+                path("api/v1/books/$bookId/complete")
+            }
+        }
 }

--- a/core/data/src/commonMain/kotlin/com/phase/bookpin/data/book/BookRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/com/phase/bookpin/data/book/BookRepositoryImpl.kt
@@ -52,4 +52,8 @@ class BookRepositoryImpl(
         )
         return dataSource.createBookmark(bookId, request).mapCatching { it.toBookmark() }
     }
+
+    override suspend fun completeBook(bookId: Long): Result<BookDetail> {
+        return dataSource.completeBook(bookId).mapCatching { it.toBookDetail() }
+    }
 }

--- a/domain/src/commonMain/kotlin/com/phase/bookpin/domain/book/BookRepository.kt
+++ b/domain/src/commonMain/kotlin/com/phase/bookpin/domain/book/BookRepository.kt
@@ -23,4 +23,6 @@ interface BookRepository {
         note: String,
         imageUrl: String,
     ): Result<Bookmark>
+
+    suspend fun completeBook(bookId: Long): Result<BookDetail>
 }

--- a/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/detail/BookDetailScreen.kt
+++ b/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/detail/BookDetailScreen.kt
@@ -43,6 +43,7 @@ fun BookDetailScreen(
     bookId: Long,
     onNavigateBack: () -> Unit = {},
     onNavigateToAddBookmark: () -> Unit = {},
+    onNavigateToHome: () -> Unit = {},
 ) {
     val viewModel: BookDetailViewModel = koinViewModel()
     val state by viewModel.uiState.collectAsStateWithLifecycle()
@@ -59,6 +60,7 @@ fun BookDetailScreen(
             }
             BookDetailSideEffect.NavigateBack -> onNavigateBack()
             BookDetailSideEffect.NavigateToAddBookmark -> onNavigateToAddBookmark()
+            BookDetailSideEffect.NavigateToHome -> onNavigateToHome()
         }
     }
 

--- a/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/detail/BookDetailSideEffect.kt
+++ b/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/detail/BookDetailSideEffect.kt
@@ -6,4 +6,5 @@ sealed interface BookDetailSideEffect {
     ) : BookDetailSideEffect
     data object NavigateBack : BookDetailSideEffect
     data object NavigateToAddBookmark : BookDetailSideEffect
+    data object NavigateToHome : BookDetailSideEffect
 }

--- a/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/detail/BookDetailViewModel.kt
+++ b/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/detail/BookDetailViewModel.kt
@@ -64,8 +64,21 @@ class BookDetailViewModel(
     }
 
     fun onMarkAsCompleteClick() {
-        reduce { copy(book = book.copy(isCompleted = true)) }
-        postSideEffect(BookDetailSideEffect.ShowSnackbar("완독으로 표시되었습니다"))
+        val bookId = uiState.value.book.id
+        if (uiState.value.isLoading) return
+        viewModelScope.launch {
+            reduce { copy(isLoading = true) }
+            bookRepository
+                .completeBook(bookId)
+                .onSuccess {
+                    reduce { copy(isLoading = false, book = book.copy(isCompleted = true)) }
+                    postSideEffect(BookDetailSideEffect.ShowSnackbar("완독으로 표시되었습니다"))
+                    postSideEffect(BookDetailSideEffect.NavigateToHome)
+                }.onFailure { error ->
+                    reduce { copy(isLoading = false) }
+                    postSideEffect(BookDetailSideEffect.ShowSnackbar(error.message ?: "오류가 발생했습니다."))
+                }
+        }
     }
 
     fun onAddBookmarkClick() {


### PR DESCRIPTION
## 1. 📄 관련된 이슈 및 소개
- 관련 이슈: closes #61
- 소개: BookDetailScreen에서 "완독으로 표시하기" 버튼 클릭 시 실제 API를 호출하고, 성공 시 홈 화면으로 이동하도록 구현

## 2. 🔥 변경된 점
- `BookRemoteDataSource`에 `completeBook()` 인터페이스 추가
- `BookRemoteDataSourceImpl`에서 `POST /api/v1/books/{bookId}/complete` API 호출 구현
- `BookRepository` 인터페이스 및 `BookRepositoryImpl`에 `completeBook()` 추가
- `BookDetailViewModel`의 `onMarkAsCompleteClick()`을 로컬 상태 변경에서 실제 API 호출로 변경
- `BookDetailSideEffect`에 `NavigateToHome` 추가
- `BookDetailScreen`에 `onNavigateToHome` 콜백 추가 및 side effect 핸들링
- `BookPinNavHost`에서 `BookDetailScreen`에 `onNavigateToHome` 전달

## 3. ✅ 필수 체크 사항
- [x] 빌드 확인
- [ ] 테스트 확인
- [ ] 코드 리뷰 요청

## 4. 📸 작업물 사진 공유(선택)

## 5. 💡 알게된 혹은 궁금한 사항
- 완독 API 호출 중 중복 클릭 방지를 위해 `isLoading` 상태를 활용
- 성공 시 스낵바 표시 후 홈 화면으로 이동