### PR TITLE
#56 : 책갈피 상세 조회 화면 구현

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,9 @@ jobs:
           echo "BASE_URL=${{ secrets.BASE_URL }}" >> local.properties
           echo "KAKAO_NATIVE_APP_KEY=${{ secrets.KAKAO_NATIVE_APP_KEY }}" >> local.properties
 
+      - name: Create google-services.json
+        run: echo '${{ secrets.GOOGLE_SERVICES_JSON }}' > android-app/google-services.json
+
       # 1) 빌드 테스트
       - name: Build (assembleDebug)
         run: ./gradlew assembleDebug --no-daemon --stacktrace

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ captures
 !*.xcworkspace/contents.xcworkspacedata
 **/xcshareddata/WorkspaceSettings.xcsettings
 node_modules/
+google-services.json

--- a/android-app/build.gradle.kts
+++ b/android-app/build.gradle.kts
@@ -9,6 +9,10 @@ plugins {
 android {
     namespace = "com.phase.bookpin.androidapp"
 
+    defaultConfig {
+        applicationId = "com.phase.bookpin"
+    }
+
     buildFeatures {
         buildConfig = true
         compose = true

--- a/android-app/build.gradle.kts
+++ b/android-app/build.gradle.kts
@@ -2,6 +2,8 @@ plugins {
     alias(libs.plugins.bookpin.android.application)
     alias(libs.plugins.composeCompiler)
     alias(libs.plugins.bookpin.ktlint)
+    alias(libs.plugins.googleServices)
+    alias(libs.plugins.firebaseCrashlyticsPlugin)
 }
 
 android {
@@ -27,6 +29,10 @@ dependencies {
 
     implementation(libs.koin.core)
     implementation(libs.koin.android)
+
+    implementation(platform(libs.firebase.bom))
+    implementation(libs.firebase.analytics)
+    implementation(libs.firebase.crashlytics)
 
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,4 +12,6 @@ plugins {
     alias(libs.plugins.ktlint)
     alias(libs.plugins.android.lint) apply false
     alias(libs.plugins.build.konfig) apply false
+    alias(libs.plugins.googleServices) apply false
+    alias(libs.plugins.firebaseCrashlyticsPlugin) apply false
 }

--- a/compose-app/src/commonMain/kotlin/com/phase/bookpin/BookPinApp.kt
+++ b/compose-app/src/commonMain/kotlin/com/phase/bookpin/BookPinApp.kt
@@ -82,6 +82,9 @@ fun BookPinApp(
                     onNavigateToBookDetail = { bookId ->
                         backStack.add(BookDetailRoute(bookId))
                     },
+                    onNavigateToBookmarkDetail = { route ->
+                        backStack.add(route)
+                    },
                     onNavigateToBookmarkTypeSelect = { bookId ->
                         backStack.add(BookmarkTypeSelectRoute(bookId))
                     },

--- a/compose-app/src/commonMain/kotlin/com/phase/bookpin/BookPinApp.kt
+++ b/compose-app/src/commonMain/kotlin/com/phase/bookpin/BookPinApp.kt
@@ -100,6 +100,11 @@ fun BookPinApp(
                     onNavigateBack = {
                         backStack.removeLastOrNull()
                     },
+                    onNavigateBackToBookDetail = {
+                        while (backStack.lastOrNull() !is BookDetailRoute) {
+                            backStack.removeLastOrNull() ?: break
+                        }
+                    },
                     onLogout = {
                         backStack.clear()
                         backStack.add(SplashRoute)

--- a/compose-app/src/commonMain/kotlin/com/phase/bookpin/navigation/BookPinNavHost.kt
+++ b/compose-app/src/commonMain/kotlin/com/phase/bookpin/navigation/BookPinNavHost.kt
@@ -8,6 +8,7 @@ import androidx.navigation3.ui.NavDisplay
 import com.phase.bookpin.bookmark.add.AddBookmarkScreen
 import com.phase.bookpin.bookmark.add.BookmarkTypeSelectScreen
 import com.phase.bookpin.bookmark.detail.BookDetailScreen
+import com.phase.bookpin.bookmark.detail.BookmarkDetailScreen
 import com.phase.bookpin.home.HomeScreen
 import com.phase.bookpin.model.bookmark.BookmarkType
 import com.phase.bookpin.search.SearchScreen
@@ -23,6 +24,7 @@ fun BookPinNavHost(
     onNavigateToBookDetail: (Long) -> Unit,
     onNavigateToBookmarkTypeSelect: (Long) -> Unit,
     onNavigateToAddBookmark: (Long, BookmarkType) -> Unit,
+    onNavigateToBookmarkDetail: (BookmarkDetailRoute) -> Unit = {},
     onNavigateToBookPreview: (BookPreviewRoute) -> Unit,
     onNavigateToSettings: () -> Unit,
     onNavigateBack: () -> Unit,
@@ -81,6 +83,35 @@ fun BookPinNavHost(
                     bookId = route.bookId,
                     onNavigateBack = onNavigateBack,
                     onNavigateToAddBookmark = { onNavigateToBookmarkTypeSelect(route.bookId) },
+                    onNavigateToBookmarkDetail = { book, bookmark ->
+                        onNavigateToBookmarkDetail(
+                            BookmarkDetailRoute(
+                                bookTitle = book.title,
+                                bookAuthor = book.author,
+                                bookImageUrl = book.imageUrl,
+                                bookmarkId = bookmark.id,
+                                pageNumber = bookmark.pageNumber,
+                                extractedText = bookmark.extractedText,
+                                note = bookmark.note,
+                                imageUrl = bookmark.imageUrl,
+                                createdAt = bookmark.createdAt,
+                            ),
+                        )
+                    },
+                )
+            }
+
+            entry<BookmarkDetailRoute> { route ->
+                BookmarkDetailScreen(
+                    bookTitle = route.bookTitle,
+                    bookAuthor = route.bookAuthor,
+                    bookImageUrl = route.bookImageUrl,
+                    pageNumber = route.pageNumber,
+                    extractedText = route.extractedText,
+                    note = route.note,
+                    imageUrl = route.imageUrl,
+                    createdAt = route.createdAt,
+                    onNavigateBack = onNavigateBack,
                 )
             }
 

--- a/compose-app/src/commonMain/kotlin/com/phase/bookpin/navigation/BookPinNavHost.kt
+++ b/compose-app/src/commonMain/kotlin/com/phase/bookpin/navigation/BookPinNavHost.kt
@@ -87,6 +87,7 @@ fun BookPinNavHost(
                     onNavigateToBookmarkDetail = { book, bookmark ->
                         onNavigateToBookmarkDetail(
                             BookmarkDetailRoute(
+                                bookId = book.id,
                                 bookTitle = book.title,
                                 bookAuthor = book.author,
                                 bookImageUrl = book.imageUrl,
@@ -104,6 +105,8 @@ fun BookPinNavHost(
 
             entry<BookmarkDetailRoute> { route ->
                 BookmarkDetailScreen(
+                    bookId = route.bookId,
+                    bookmarkId = route.bookmarkId,
                     bookTitle = route.bookTitle,
                     bookAuthor = route.bookAuthor,
                     bookImageUrl = route.bookImageUrl,

--- a/compose-app/src/commonMain/kotlin/com/phase/bookpin/navigation/BookPinNavHost.kt
+++ b/compose-app/src/commonMain/kotlin/com/phase/bookpin/navigation/BookPinNavHost.kt
@@ -28,6 +28,7 @@ fun BookPinNavHost(
     onNavigateToBookPreview: (BookPreviewRoute) -> Unit,
     onNavigateToSettings: () -> Unit,
     onNavigateBack: () -> Unit,
+    onNavigateBackToBookDetail: () -> Unit,
     onLogout: () -> Unit,
 ) {
     NavDisplay(
@@ -133,6 +134,7 @@ fun BookPinNavHost(
                     bookId = route.bookId,
                     bookmarkType = route.bookmarkType,
                     onNavigateBack = onNavigateBack,
+                    onBookmarkSaved = onNavigateBackToBookDetail,
                 )
             }
 

--- a/compose-app/src/commonMain/kotlin/com/phase/bookpin/navigation/Route.kt
+++ b/compose-app/src/commonMain/kotlin/com/phase/bookpin/navigation/Route.kt
@@ -35,6 +35,19 @@ data class AddBookmarkRoute(
 ) : NavKey
 
 @Serializable
+data class BookmarkDetailRoute(
+    val bookTitle: String,
+    val bookAuthor: String,
+    val bookImageUrl: String,
+    val bookmarkId: Long,
+    val pageNumber: Int,
+    val extractedText: String,
+    val note: String,
+    val imageUrl: String,
+    val createdAt: String,
+) : NavKey
+
+@Serializable
 data class BookPreviewRoute(
     val title: String = "",
     val author: String = "",
@@ -52,6 +65,7 @@ val navSerializersModule = SerializersModule {
         subclass(BookmarkTypeSelectRoute::class, BookmarkTypeSelectRoute.serializer())
         subclass(AddBookmarkRoute::class, AddBookmarkRoute.serializer())
         subclass(SettingsRoute::class, SettingsRoute.serializer())
+        subclass(BookmarkDetailRoute::class, BookmarkDetailRoute.serializer())
         subclass(BookPreviewRoute::class, BookPreviewRoute.serializer())
     }
 }

--- a/compose-app/src/commonMain/kotlin/com/phase/bookpin/navigation/Route.kt
+++ b/compose-app/src/commonMain/kotlin/com/phase/bookpin/navigation/Route.kt
@@ -36,6 +36,7 @@ data class AddBookmarkRoute(
 
 @Serializable
 data class BookmarkDetailRoute(
+    val bookId: Long,
     val bookTitle: String,
     val bookAuthor: String,
     val bookImageUrl: String,

--- a/core/data-api/src/commonMain/kotlin/com/phase/bookpin/data/api/book/AddBookmarkRequest.kt
+++ b/core/data-api/src/commonMain/kotlin/com/phase/bookpin/data/api/book/AddBookmarkRequest.kt
@@ -3,9 +3,9 @@ package com.phase.bookpin.data.api.book
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class CreateBookmarkRequest(
+data class AddBookmarkRequest(
     val pageNumber: Int,
     val extractedText: String,
     val note: String,
-    val imageUrl: String,
+    val imageUrl: String?,
 )

--- a/core/data-api/src/commonMain/kotlin/com/phase/bookpin/data/api/book/BookRemoteDataSource.kt
+++ b/core/data-api/src/commonMain/kotlin/com/phase/bookpin/data/api/book/BookRemoteDataSource.kt
@@ -14,4 +14,6 @@ interface BookRemoteDataSource {
     suspend fun createBookmark(bookId: Long, request: CreateBookmarkRequest): Result<BookmarkResponse>
 
     suspend fun completeBook(bookId: Long): Result<BookDetailResponse>
+
+    suspend fun deleteBookmark(bookId: Long, bookmarkId: Long): Result<Unit>
 }

--- a/core/data-api/src/commonMain/kotlin/com/phase/bookpin/data/api/book/BookRemoteDataSource.kt
+++ b/core/data-api/src/commonMain/kotlin/com/phase/bookpin/data/api/book/BookRemoteDataSource.kt
@@ -11,7 +11,7 @@ interface BookRemoteDataSource {
 
     suspend fun getPhotoBookmarks(bookId: Long): Result<List<BookmarkResponse>>
 
-    suspend fun createBookmark(bookId: Long, request: CreateBookmarkRequest): Result<BookmarkResponse>
+    suspend fun addBookmark(bookId: Long, request: AddBookmarkRequest): Result<BookmarkResponse>
 
     suspend fun completeBook(bookId: Long): Result<BookDetailResponse>
 

--- a/core/data-api/src/commonMain/kotlin/com/phase/bookpin/data/api/book/BookmarkResponse.kt
+++ b/core/data-api/src/commonMain/kotlin/com/phase/bookpin/data/api/book/BookmarkResponse.kt
@@ -20,5 +20,6 @@ data class BookmarkResponse(
         extractedText = extractedText,
         note = note,
         imageUrl = imageUrl,
+        createdAt = createdAt,
     )
 }

--- a/core/data-remote/src/commonMain/kotlin/com/phase/bookpin/data/remote/book/BookRemoteDataSourceImpl.kt
+++ b/core/data-remote/src/commonMain/kotlin/com/phase/bookpin/data/remote/book/BookRemoteDataSourceImpl.kt
@@ -74,4 +74,12 @@ class BookRemoteDataSourceImpl(
                 path("api/v1/books/$bookId/complete")
             }
         }
+
+    override suspend fun deleteBookmark(bookId: Long, bookmarkId: Long): Result<Unit> =
+        httpClient.safeRequest {
+            url {
+                method = HttpMethod.Delete
+                path("api/v1/books/$bookId/bookmarks/$bookmarkId")
+            }
+        }
 }

--- a/core/data-remote/src/commonMain/kotlin/com/phase/bookpin/data/remote/book/BookRemoteDataSourceImpl.kt
+++ b/core/data-remote/src/commonMain/kotlin/com/phase/bookpin/data/remote/book/BookRemoteDataSourceImpl.kt
@@ -4,7 +4,7 @@ import com.phase.bookpin.data.api.book.BookDetailResponse
 import com.phase.bookpin.data.api.book.BookItemResponse
 import com.phase.bookpin.data.api.book.BookRemoteDataSource
 import com.phase.bookpin.data.api.book.BookmarkResponse
-import com.phase.bookpin.data.api.book.CreateBookmarkRequest
+import com.phase.bookpin.data.api.book.AddBookmarkRequest
 import com.phase.bookpin.data.api.book.LatestBookmarkResponse
 import com.phase.bookpin.data.remote.client.safeRequest
 import io.ktor.client.HttpClient
@@ -55,9 +55,9 @@ class BookRemoteDataSourceImpl(
             }
         }
 
-    override suspend fun createBookmark(
+    override suspend fun addBookmark(
         bookId: Long,
-        request: CreateBookmarkRequest,
+        request: AddBookmarkRequest,
     ): Result<BookmarkResponse> =
         httpClient.safeRequest {
             url {

--- a/core/data/src/commonMain/kotlin/com/phase/bookpin/data/book/BookRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/com/phase/bookpin/data/book/BookRepositoryImpl.kt
@@ -56,4 +56,8 @@ class BookRepositoryImpl(
     override suspend fun completeBook(bookId: Long): Result<BookDetail> {
         return dataSource.completeBook(bookId).mapCatching { it.toBookDetail() }
     }
+
+    override suspend fun deleteBookmark(bookId: Long, bookmarkId: Long): Result<Unit> {
+        return dataSource.deleteBookmark(bookId, bookmarkId)
+    }
 }

--- a/core/data/src/commonMain/kotlin/com/phase/bookpin/data/book/BookRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/com/phase/bookpin/data/book/BookRepositoryImpl.kt
@@ -1,7 +1,7 @@
 package com.phase.bookpin.data.book
 
 import com.phase.bookpin.data.api.book.BookRemoteDataSource
-import com.phase.bookpin.data.api.book.CreateBookmarkRequest
+import com.phase.bookpin.data.api.book.AddBookmarkRequest
 import com.phase.bookpin.domain.book.BookRepository
 import com.phase.bookpin.model.book.BookDetail
 import com.phase.bookpin.model.book.BookItem
@@ -37,20 +37,20 @@ class BookRepositoryImpl(
         }
     }
 
-    override suspend fun createBookmark(
+    override suspend fun addBookmark(
         bookId: Long,
         pageNumber: Int,
         extractedText: String,
         note: String,
-        imageUrl: String,
+        imageUrl: String?,
     ): Result<Bookmark> {
-        val request = CreateBookmarkRequest(
+        val request = AddBookmarkRequest(
             pageNumber = pageNumber,
             extractedText = extractedText,
             note = note,
             imageUrl = imageUrl,
         )
-        return dataSource.createBookmark(bookId, request).mapCatching { it.toBookmark() }
+        return dataSource.addBookmark(bookId, request).mapCatching { it.toBookmark() }
     }
 
     override suspend fun completeBook(bookId: Long): Result<BookDetail> {

--- a/designsystem/src/commonMain/kotlin/com/phase/bookpin/designsystem/component/BPCloseButton.kt
+++ b/designsystem/src/commonMain/kotlin/com/phase/bookpin/designsystem/component/BPCloseButton.kt
@@ -1,0 +1,37 @@
+package com.phase.bookpin.designsystem.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import bookpin.designsystem.generated.resources.Res
+import bookpin.designsystem.generated.resources.ic_close
+import com.phase.bookpin.designsystem.BookPinTheme
+import org.jetbrains.compose.resources.painterResource
+
+@Composable
+fun BPCloseButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    IconButton(
+        onClick = onClick,
+        modifier = modifier
+            .size(36.dp)
+            .background(
+                color = BookPinTheme.colors.bgSurface,
+                shape = CircleShape,
+            ),
+    ) {
+        Icon(
+            painter = painterResource(Res.drawable.ic_close),
+            contentDescription = null,
+            modifier = Modifier.size(18.dp),
+            tint = BookPinTheme.colors.iconDefault,
+        )
+    }
+}

--- a/designsystem/src/commonMain/kotlin/com/phase/bookpin/designsystem/component/BPLoadingScreen.kt
+++ b/designsystem/src/commonMain/kotlin/com/phase/bookpin/designsystem/component/BPLoadingScreen.kt
@@ -14,7 +14,7 @@ fun BPLoadingScreen(modifier: Modifier = Modifier) {
     Box(
         modifier = modifier
             .fillMaxSize()
-            .background(BookPinTheme.colors.bgCanvas),
+            .background(BookPinTheme.colors.bgCanvas.copy(alpha = 0.6f)),
         contentAlignment = Alignment.Center,
     ) {
         CircularProgressIndicator(

--- a/designsystem/src/commonMain/kotlin/com/phase/bookpin/designsystem/component/BPTopBar.kt
+++ b/designsystem/src/commonMain/kotlin/com/phase/bookpin/designsystem/component/BPTopBar.kt
@@ -1,10 +1,6 @@
 package com.phase.bookpin.designsystem.component
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -13,66 +9,42 @@ import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
-import bookpin.designsystem.generated.resources.Res
-import bookpin.designsystem.generated.resources.ic_close
 import com.phase.bookpin.designsystem.BookPinTheme
-import org.jetbrains.compose.resources.painterResource
-
-@Composable
-fun BPTopBar(
-    title: String,
-    onClose: () -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    val borderColor = BookPinTheme.colors.borderSubtle
-
-    Box(
-        modifier = modifier
-            .fillMaxWidth()
-            .drawBottomBorder(borderColor)
-            .padding(horizontal = 16.dp, vertical = 12.dp),
-    ) {
-        Text(
-            text = title,
-            style = BookPinTheme.typography.headlineSmall,
-            color = BookPinTheme.colors.textPrimary,
-            modifier = Modifier.align(Alignment.CenterStart),
-        )
-
-        IconButton(
-            onClick = onClose,
-            modifier = Modifier
-                .size(36.dp)
-                .background(
-                    color = BookPinTheme.colors.bgSurface,
-                    shape = CircleShape,
-                )
-                .align(Alignment.CenterEnd),
-        ) {
-            Icon(
-                painter = painterResource(Res.drawable.ic_close),
-                contentDescription = null,
-                modifier = Modifier.size(18.dp),
-                tint = BookPinTheme.colors.iconDefault,
-            )
-        }
-    }
-}
 
 @Composable
 fun BPTopBar(
     modifier: Modifier = Modifier,
+    title: String? = null,
     navigationIcon: @Composable (() -> Unit)? = null,
     actions: @Composable (RowScope.() -> Unit)? = null,
+    showBottomBorder: Boolean = false,
 ) {
+    val borderModifier = if (showBottomBorder) {
+        modifier.drawBottomBorder(BookPinTheme.colors.borderSubtle)
+    } else {
+        modifier
+    }
+
     Box(
-        modifier = modifier
+        modifier = borderModifier
             .fillMaxWidth()
             .padding(horizontal = 16.dp, vertical = 12.dp),
     ) {
-        if (navigationIcon != null) {
-            Box(modifier = Modifier.align(Alignment.CenterStart)) {
-                navigationIcon()
+        if (navigationIcon != null || title != null) {
+            Row(
+                modifier = Modifier.align(Alignment.CenterStart),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                if (navigationIcon != null) {
+                    navigationIcon()
+                }
+                if (title != null) {
+                    Text(
+                        text = title,
+                        style = BookPinTheme.typography.headlineSmall,
+                        color = BookPinTheme.colors.textPrimary,
+                    )
+                }
             }
         }
 

--- a/designsystem/src/commonMain/kotlin/com/phase/bookpin/designsystem/component/BPTopBar.kt
+++ b/designsystem/src/commonMain/kotlin/com/phase/bookpin/designsystem/component/BPTopBar.kt
@@ -59,6 +59,31 @@ fun BPTopBar(
     }
 }
 
+@Composable
+fun BPTopBar(
+    modifier: Modifier = Modifier,
+    navigationIcon: @Composable (() -> Unit)? = null,
+    actions: @Composable (RowScope.() -> Unit)? = null,
+) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+    ) {
+        if (navigationIcon != null) {
+            Box(modifier = Modifier.align(Alignment.CenterStart)) {
+                navigationIcon()
+            }
+        }
+
+        if (actions != null) {
+            Row(modifier = Modifier.align(Alignment.CenterEnd)) {
+                actions()
+            }
+        }
+    }
+}
+
 private fun Modifier.drawBottomBorder(color: Color): Modifier = this.then(
     Modifier.drawWithContent {
         drawContent()

--- a/domain/src/commonMain/kotlin/com/phase/bookpin/domain/book/BookRepository.kt
+++ b/domain/src/commonMain/kotlin/com/phase/bookpin/domain/book/BookRepository.kt
@@ -16,12 +16,12 @@ interface BookRepository {
 
     suspend fun getPhotoBookmarks(bookId: Long): Result<List<Bookmark>>
 
-    suspend fun createBookmark(
+    suspend fun addBookmark(
         bookId: Long,
         pageNumber: Int,
         extractedText: String,
         note: String,
-        imageUrl: String,
+        imageUrl: String?,
     ): Result<Bookmark>
 
     suspend fun completeBook(bookId: Long): Result<BookDetail>

--- a/domain/src/commonMain/kotlin/com/phase/bookpin/domain/book/BookRepository.kt
+++ b/domain/src/commonMain/kotlin/com/phase/bookpin/domain/book/BookRepository.kt
@@ -25,4 +25,6 @@ interface BookRepository {
     ): Result<Bookmark>
 
     suspend fun completeBook(bookId: Long): Result<BookDetail>
+
+    suspend fun deleteBookmark(bookId: Long, bookmarkId: Long): Result<Unit>
 }

--- a/feature/bookmark/src/commonMain/composeResources/drawable/ic_delete.xml
+++ b/feature/bookmark/src/commonMain/composeResources/drawable/ic_delete.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#000000"
+        android:pathData="M7,21q-0.825,0 -1.412,-0.587Q5,19.825 5,19V6H4V4h5V3h6v1h5v2h-1v13q0,0.825 -0.587,1.413Q17.825,21 17,21ZM17,6H7v13h10ZM9,17h2V8H9Zm4,0h2V8h-2ZM7,6v13Z" />
+</vector>

--- a/feature/bookmark/src/commonMain/composeResources/values/strings.xml
+++ b/feature/bookmark/src/commonMain/composeResources/values/strings.xml
@@ -28,7 +28,10 @@
     <!-- Bookmark Detail -->
     <string name="bookmark_detail_content">책 내용</string>
     <string name="bookmark_detail_memo">개인 메모</string>
-    <string name="bookmark_detail_delete_preparing">준비 중입니다.</string>
+    <string name="bookmark_delete_title">책갈피 삭제</string>
+    <string name="bookmark_delete_description">이 책갈피를 삭제하시겠습니까?</string>
+    <string name="bookmark_delete_cancel">취소</string>
+    <string name="bookmark_delete_confirm">삭제</string>
 
     <!-- Content Descriptions -->
     <string name="cd_back">뒤로가기</string>

--- a/feature/bookmark/src/commonMain/composeResources/values/strings.xml
+++ b/feature/bookmark/src/commonMain/composeResources/values/strings.xml
@@ -25,9 +25,15 @@
     <string name="bookmark_memo_placeholder">생각을 기록하세요 (선택사항)</string>
     <string name="bookmark_save">책갈피 저장</string>
 
+    <!-- Bookmark Detail -->
+    <string name="bookmark_detail_content">책 내용</string>
+    <string name="bookmark_detail_memo">개인 메모</string>
+    <string name="bookmark_detail_delete_preparing">준비 중입니다.</string>
+
     <!-- Content Descriptions -->
     <string name="cd_back">뒤로가기</string>
     <string name="cd_add_bookmark">북마크 추가</string>
     <string name="cd_text_bookmark">텍스트 북마크</string>
     <string name="cd_photo_bookmark">사진 북마크</string>
+    <string name="cd_delete_bookmark">책갈피 삭제</string>
 </resources>

--- a/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/add/AddBookmarkScreen.kt
+++ b/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/add/AddBookmarkScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
@@ -42,6 +43,7 @@ fun AddBookmarkScreen(
     bookId: Long,
     bookmarkType: BookmarkType,
     onNavigateBack: () -> Unit,
+    onBookmarkSaved: () -> Unit,
 ) {
     val viewModel: AddBookmarkViewModel = koinViewModel()
     val state by viewModel.uiState.collectAsStateWithLifecycle()
@@ -72,8 +74,12 @@ fun AddBookmarkScreen(
     }
 
     LaunchedEffect(bookId, bookmarkType) {
-        viewModel.init(bookId, bookmarkType)
+        viewModel.onScreenEnter(bookId, bookmarkType)
         launchPicker(bookmarkType)
+    }
+
+    DisposableEffect(Unit) {
+        onDispose { viewModel.onScreenExit() }
     }
 
     viewModel.sideEffect.collectSideEffect {
@@ -82,7 +88,7 @@ fun AddBookmarkScreen(
                 snackbarHost.showSnackbar(it.message)
             }
             AddBookmarkSideEffect.NavigateBack -> onNavigateBack()
-            AddBookmarkSideEffect.BookmarkSaved -> onNavigateBack()
+            AddBookmarkSideEffect.BookmarkSaved -> onBookmarkSaved()
         }
     }
 

--- a/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/add/AddBookmarkScreen.kt
+++ b/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/add/AddBookmarkScreen.kt
@@ -28,6 +28,7 @@ import coil3.compose.AsyncImage
 import com.phase.bookpin.common.extensions.collectSideEffect
 import com.phase.bookpin.common.snackbar.LocalSnackbarHost
 import com.phase.bookpin.designsystem.BookPinTheme
+import com.phase.bookpin.designsystem.component.BPCloseButton
 import com.phase.bookpin.designsystem.component.BPLoadingScreen
 import com.phase.bookpin.designsystem.component.BPTextArea
 import com.phase.bookpin.designsystem.component.BPTopBar
@@ -93,7 +94,8 @@ fun AddBookmarkScreen(
         ) {
             BPTopBar(
                 title = stringResource(Res.string.bookmark_add_title),
-                onClose = viewModel::onCloseClick,
+                actions = { BPCloseButton(onClick = viewModel::onCloseClick) },
+                showBottomBorder = true,
             )
 
             Column(

--- a/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/add/AddBookmarkViewModel.kt
+++ b/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/add/AddBookmarkViewModel.kt
@@ -58,7 +58,7 @@ class AddBookmarkViewModel(
                     imageRepository.uploadImage(bytes, extension).getOrThrow()
                 }
             } else {
-                Result.success("")
+                Result.success(null)
             }
 
             imageUrlResult.onFailure { error ->
@@ -74,7 +74,7 @@ class AddBookmarkViewModel(
             val imageUrl = imageUrlResult.getOrThrow()
 
             bookRepository
-                .createBookmark(
+                .addBookmark(
                     bookId = bookId,
                     pageNumber = pageNumber,
                     extractedText = state.extractedText,

--- a/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/add/AddBookmarkViewModel.kt
+++ b/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/add/AddBookmarkViewModel.kt
@@ -17,9 +17,13 @@ class AddBookmarkViewModel(
 
     private var bookId: Long = 0L
 
-    fun init(bookId: Long, bookmarkType: BookmarkType) {
+    fun onScreenEnter(bookId: Long, bookmarkType: BookmarkType) {
         this.bookId = bookId
         reduce { copy(bookmarkType = bookmarkType) }
+    }
+
+    fun onScreenExit() {
+        reduce { AddBookmarkState() }
     }
 
     fun onExtractedTextChanged(text: String) {

--- a/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/add/BookmarkTypeSelectScreen.kt
+++ b/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/add/BookmarkTypeSelectScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.unit.dp
 import bookpin.bookmark.generated.resources.*
 import com.phase.bookpin.bookmark.component.BookmarkTypeOptionCard
 import com.phase.bookpin.designsystem.BookPinTheme
+import com.phase.bookpin.designsystem.component.BPCloseButton
 import com.phase.bookpin.designsystem.component.BPTopBar
 import com.phase.bookpin.model.bookmark.BookmarkType
 import org.jetbrains.compose.resources.painterResource
@@ -29,7 +30,8 @@ fun BookmarkTypeSelectScreen(
     ) {
         BPTopBar(
             title = stringResource(Res.string.bookmark_add_title),
-            onClose = onNavigateBack,
+            actions = { BPCloseButton(onClick = onNavigateBack) },
+            showBottomBorder = true,
         )
 
         Column(

--- a/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/detail/BookDetailScreen.kt
+++ b/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/detail/BookDetailScreen.kt
@@ -43,6 +43,7 @@ fun BookDetailScreen(
     bookId: Long,
     onNavigateBack: () -> Unit = {},
     onNavigateToAddBookmark: () -> Unit = {},
+    onNavigateToBookmarkDetail: (book: BookDetail, bookmark: Bookmark) -> Unit = { _, _ -> },
 ) {
     val viewModel: BookDetailViewModel = koinViewModel()
     val state by viewModel.uiState.collectAsStateWithLifecycle()
@@ -59,6 +60,9 @@ fun BookDetailScreen(
             }
             BookDetailSideEffect.NavigateBack -> onNavigateBack()
             BookDetailSideEffect.NavigateToAddBookmark -> onNavigateToAddBookmark()
+            is BookDetailSideEffect.NavigateToBookmarkDetail -> {
+                onNavigateToBookmarkDetail(state.book, it.bookmark)
+            }
         }
     }
 
@@ -122,7 +126,10 @@ fun BookDetailScreen(
 
                 if (state.selectedTab == BookmarkTab.TEXT) {
                     items(state.textBookmarks, key = { it.id }) { bookmark ->
-                        TextBookmarkItem(bookmark = bookmark)
+                        TextBookmarkItem(
+                            bookmark = bookmark,
+                            onClick = { viewModel.onBookmarkClick(bookmark) },
+                        )
                     }
                 } else {
                     items(state.photoBookmarks.chunked(2)) { rowItems ->
@@ -136,6 +143,7 @@ fun BookDetailScreen(
                             rowItems.forEach { bookmark ->
                                 PhotoBookmarkItem(
                                     bookmark = bookmark,
+                                    onClick = { viewModel.onBookmarkClick(bookmark) },
                                     modifier = Modifier.weight(1f),
                                 )
                             }
@@ -374,6 +382,7 @@ private fun TabItem(
 @Composable
 private fun TextBookmarkItem(
     bookmark: Bookmark,
+    onClick: () -> Unit,
 ) {
     Column(
         modifier = Modifier
@@ -386,7 +395,9 @@ private fun TextBookmarkItem(
             ).background(
                 color = BookPinTheme.colors.bgElevated,
                 shape = RoundedCornerShape(16.dp),
-            ).padding(16.dp),
+            ).clip(RoundedCornerShape(16.dp))
+            .clickable(onClick = onClick)
+            .padding(16.dp),
     ) {
         Text(
             text = stringResource(Res.string.page_format, bookmark.pageNumber),
@@ -419,6 +430,7 @@ private fun TextBookmarkItem(
 @Composable
 private fun PhotoBookmarkItem(
     bookmark: Bookmark,
+    onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -433,7 +445,8 @@ private fun PhotoBookmarkItem(
                 width = 0.5.dp,
                 color = BookPinTheme.colors.borderSubtle,
                 shape = RoundedCornerShape(16.dp),
-            ).clip(RoundedCornerShape(16.dp)),
+            ).clip(RoundedCornerShape(16.dp))
+            .clickable(onClick = onClick),
     ) {
         Box(
             modifier = Modifier

--- a/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/detail/BookDetailSideEffect.kt
+++ b/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/detail/BookDetailSideEffect.kt
@@ -1,9 +1,14 @@
 package com.phase.bookpin.bookmark.detail
 
+import com.phase.bookpin.model.book.Bookmark
+
 sealed interface BookDetailSideEffect {
     data class ShowSnackbar(
         val message: String,
     ) : BookDetailSideEffect
     data object NavigateBack : BookDetailSideEffect
     data object NavigateToAddBookmark : BookDetailSideEffect
+    data class NavigateToBookmarkDetail(
+        val bookmark: Bookmark,
+    ) : BookDetailSideEffect
 }

--- a/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/detail/BookDetailViewModel.kt
+++ b/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/detail/BookDetailViewModel.kt
@@ -3,6 +3,7 @@ package com.phase.bookpin.bookmark.detail
 import androidx.lifecycle.viewModelScope
 import com.phase.bookpin.common.BaseViewModel
 import com.phase.bookpin.domain.book.BookRepository
+import com.phase.bookpin.model.book.Bookmark
 import kotlinx.coroutines.launch
 
 class BookDetailViewModel(
@@ -70,5 +71,9 @@ class BookDetailViewModel(
 
     fun onAddBookmarkClick() {
         postSideEffect(BookDetailSideEffect.NavigateToAddBookmark)
+    }
+
+    fun onBookmarkClick(bookmark: Bookmark) {
+        postSideEffect(BookDetailSideEffect.NavigateToBookmarkDetail(bookmark))
     }
 }

--- a/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/detail/BookmarkDetailScreen.kt
+++ b/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/detail/BookmarkDetailScreen.kt
@@ -163,7 +163,7 @@ private fun BookInfoSection(
     ) {
         AsyncImage(
             model = bookImageUrl,
-            contentDescription = null,
+            contentDescription = bookTitle,
             modifier = Modifier
                 .width(48.dp)
                 .height(72.dp)
@@ -194,7 +194,7 @@ private fun BookInfoSection(
             Spacer(modifier = Modifier.height(2.dp))
 
             Text(
-                text = "p.$pageNumber · $createdAt",
+                text = "${stringResource(Res.string.page_format, pageNumber)} · $createdAt",
                 style = BookPinTheme.typography.bodySmall,
                 color = BookPinTheme.colors.textSecondary,
             )
@@ -215,7 +215,7 @@ private fun BookmarkPhotoSection(
 ) {
     AsyncImage(
         model = imageUrl,
-        contentDescription = null,
+        contentDescription = stringResource(Res.string.cd_photo_bookmark),
         modifier = Modifier
             .fillMaxWidth()
             .clip(RoundedCornerShape(16.dp))

--- a/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/detail/BookmarkDetailScreen.kt
+++ b/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/detail/BookmarkDetailScreen.kt
@@ -11,6 +11,8 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -23,14 +25,20 @@ import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.unit.dp
 import bookpin.bookmark.generated.resources.*
 import coil3.compose.AsyncImage
+import com.phase.bookpin.common.extensions.collectSideEffect
 import com.phase.bookpin.common.snackbar.LocalSnackbarHost
 import com.phase.bookpin.designsystem.BookPinTheme
+import com.phase.bookpin.designsystem.component.BPConfirmDialog
+import com.phase.bookpin.designsystem.component.BPLoadingScreen
 import com.phase.bookpin.designsystem.component.BPTopBar
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
+import org.koin.compose.viewmodel.koinViewModel
 
 @Composable
 fun BookmarkDetailScreen(
+    bookId: Long,
+    bookmarkId: Long,
     bookTitle: String,
     bookAuthor: String,
     bookImageUrl: String,
@@ -40,9 +48,26 @@ fun BookmarkDetailScreen(
     imageUrl: String,
     createdAt: String,
     onNavigateBack: () -> Unit,
+    viewModel: BookmarkDetailViewModel = koinViewModel(),
 ) {
+    val state by viewModel.uiState.collectAsState()
     val snackbarHost = LocalSnackbarHost.current
-    val deletePreparingMessage = stringResource(Res.string.bookmark_detail_delete_preparing)
+
+    viewModel.sideEffect.collectSideEffect { sideEffect ->
+        when (sideEffect) {
+            is BookmarkDetailSideEffect.ShowSnackbar -> {
+                snackbarHost.showSnackbar(sideEffect.message)
+            }
+            is BookmarkDetailSideEffect.NavigateBack -> {
+                onNavigateBack()
+            }
+        }
+    }
+
+    if (state.isLoading) {
+        BPLoadingScreen()
+        return
+    }
 
     Column(
         modifier = Modifier
@@ -65,7 +90,7 @@ fun BookmarkDetailScreen(
             },
             actions = {
                 IconButton(
-                    onClick = { snackbarHost.showSnackbar(deletePreparingMessage) },
+                    onClick = { viewModel.onDeleteClick() },
                     modifier = Modifier.size(36.dp),
                 ) {
                     Icon(
@@ -77,6 +102,18 @@ fun BookmarkDetailScreen(
                 }
             },
         )
+
+        if (state.showDeleteDialog) {
+            BPConfirmDialog(
+                title = stringResource(Res.string.bookmark_delete_title),
+                description = stringResource(Res.string.bookmark_delete_description),
+                cancelText = stringResource(Res.string.bookmark_delete_cancel),
+                confirmText = stringResource(Res.string.bookmark_delete_confirm),
+                confirmButtonColor = BookPinTheme.colors.error,
+                onDismiss = viewModel::onDeleteDismiss,
+                onConfirm = { viewModel.onDeleteConfirm(bookId, bookmarkId) },
+            )
+        }
 
         Column(
             modifier = Modifier

--- a/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/detail/BookmarkDetailScreen.kt
+++ b/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/detail/BookmarkDetailScreen.kt
@@ -1,0 +1,293 @@
+package com.phase.bookpin.bookmark.detail
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.unit.dp
+import bookpin.bookmark.generated.resources.*
+import coil3.compose.AsyncImage
+import com.phase.bookpin.common.snackbar.LocalSnackbarHost
+import com.phase.bookpin.designsystem.BookPinTheme
+import com.phase.bookpin.designsystem.component.BPTopBar
+import org.jetbrains.compose.resources.painterResource
+import org.jetbrains.compose.resources.stringResource
+
+@Composable
+fun BookmarkDetailScreen(
+    bookTitle: String,
+    bookAuthor: String,
+    bookImageUrl: String,
+    pageNumber: Int,
+    extractedText: String,
+    note: String,
+    imageUrl: String,
+    createdAt: String,
+    onNavigateBack: () -> Unit,
+) {
+    val snackbarHost = LocalSnackbarHost.current
+    val deletePreparingMessage = stringResource(Res.string.bookmark_detail_delete_preparing)
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(BookPinTheme.colors.bgCanvas),
+    ) {
+        BPTopBar(
+            navigationIcon = {
+                IconButton(
+                    onClick = onNavigateBack,
+                    modifier = Modifier.size(36.dp),
+                ) {
+                    Icon(
+                        painter = painterResource(Res.drawable.ic_arrow_back),
+                        contentDescription = stringResource(Res.string.cd_back),
+                        modifier = Modifier.size(20.dp),
+                        tint = BookPinTheme.colors.iconDefault,
+                    )
+                }
+            },
+            actions = {
+                IconButton(
+                    onClick = { snackbarHost.showSnackbar(deletePreparingMessage) },
+                    modifier = Modifier.size(36.dp),
+                ) {
+                    Icon(
+                        painter = painterResource(Res.drawable.ic_delete),
+                        contentDescription = stringResource(Res.string.cd_delete_bookmark),
+                        modifier = Modifier.size(20.dp),
+                        tint = BookPinTheme.colors.iconDefault,
+                    )
+                }
+            },
+        )
+
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 24.dp),
+        ) {
+            Spacer(modifier = Modifier.height(16.dp))
+
+            BookInfoSection(
+                bookTitle = bookTitle,
+                bookAuthor = bookAuthor,
+                bookImageUrl = bookImageUrl,
+                pageNumber = pageNumber,
+                createdAt = createdAt,
+            )
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            if (imageUrl.isNotEmpty()) {
+                BookmarkPhotoSection(imageUrl = imageUrl)
+                Spacer(modifier = Modifier.height(24.dp))
+            }
+
+            BookContentSection(extractedText = extractedText)
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            PersonalMemoSection(note = note)
+
+            Spacer(modifier = Modifier.height(32.dp))
+        }
+    }
+}
+
+@Composable
+private fun BookInfoSection(
+    bookTitle: String,
+    bookAuthor: String,
+    bookImageUrl: String,
+    pageNumber: Int,
+    createdAt: String,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        AsyncImage(
+            model = bookImageUrl,
+            contentDescription = null,
+            modifier = Modifier
+                .width(48.dp)
+                .height(72.dp)
+                .clip(RoundedCornerShape(4.dp))
+                .background(BookPinTheme.colors.bgSurface),
+            contentScale = ContentScale.Crop,
+        )
+
+        Spacer(modifier = Modifier.width(12.dp))
+
+        Column(
+            modifier = Modifier.weight(1f),
+        ) {
+            Text(
+                text = bookTitle,
+                style = BookPinTheme.typography.titleMedium,
+                color = BookPinTheme.colors.textPrimary,
+            )
+
+            Spacer(modifier = Modifier.height(2.dp))
+
+            Text(
+                text = bookAuthor,
+                style = BookPinTheme.typography.bodyMedium,
+                color = BookPinTheme.colors.textSecondary,
+            )
+
+            Spacer(modifier = Modifier.height(2.dp))
+
+            Text(
+                text = "p.$pageNumber · $createdAt",
+                style = BookPinTheme.typography.bodySmall,
+                color = BookPinTheme.colors.textSecondary,
+            )
+        }
+    }
+
+    Spacer(modifier = Modifier.height(16.dp))
+
+    HorizontalDivider(
+        color = BookPinTheme.colors.borderSubtle.copy(alpha = 0.5f),
+        thickness = 1.dp,
+    )
+}
+
+@Composable
+private fun BookmarkPhotoSection(
+    imageUrl: String,
+) {
+    AsyncImage(
+        model = imageUrl,
+        contentDescription = null,
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(16.dp))
+            .border(
+                width = 1.dp,
+                color = BookPinTheme.colors.borderSubtle,
+                shape = RoundedCornerShape(16.dp),
+            ),
+        contentScale = ContentScale.FillWidth,
+    )
+}
+
+@Composable
+private fun BookContentSection(
+    extractedText: String,
+) {
+    Text(
+        text = stringResource(Res.string.bookmark_detail_content),
+        style = BookPinTheme.typography.titleMedium,
+        color = BookPinTheme.colors.textTertiary,
+    )
+
+    Spacer(modifier = Modifier.height(8.dp))
+
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .shadow(
+                elevation = 2.dp,
+                shape = RoundedCornerShape(16.dp),
+            ).background(
+                color = BookPinTheme.colors.bgElevated,
+                shape = RoundedCornerShape(16.dp),
+            ).padding(16.dp),
+    ) {
+        Text(
+            text = extractedText,
+            style = BookPinTheme.typography.bodyMedium,
+            color = BookPinTheme.colors.textPrimary,
+        )
+    }
+}
+
+@Composable
+private fun PersonalMemoSection(
+    note: String,
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .drawDashedTopBorder(
+                color = BookPinTheme.colors.borderDefault,
+            ).padding(top = 16.dp),
+    ) {
+        Column {
+            Text(
+                text = stringResource(Res.string.bookmark_detail_memo),
+                style = BookPinTheme.typography.titleMedium,
+                color = BookPinTheme.colors.textTertiary,
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .shadow(
+                        elevation = 2.dp,
+                        shape = RoundedCornerShape(16.dp),
+                    ).background(
+                        color = BookPinTheme.colors.bgElevated,
+                        shape = RoundedCornerShape(16.dp),
+                    ).padding(16.dp),
+            ) {
+                Text(
+                    text = note.ifEmpty { "-" },
+                    style = BookPinTheme.typography.bodyMedium.copy(
+                        fontStyle = if (note.isEmpty()) FontStyle.Italic else FontStyle.Normal,
+                    ),
+                    color = if (note.isEmpty()) {
+                        BookPinTheme.colors.textPlaceholder
+                    } else {
+                        BookPinTheme.colors.textPrimary
+                    },
+                )
+            }
+        }
+    }
+}
+
+private fun Modifier.drawDashedTopBorder(
+    color: Color,
+): Modifier = this.then(
+    Modifier.drawBehind {
+        val dashWidth = 6.dp.toPx()
+        val dashGap = 4.dp.toPx()
+        val strokeWidth = 1.dp.toPx()
+        var x = 0f
+        while (x < size.width) {
+            drawLine(
+                color = color,
+                start = Offset(x, 0f),
+                end = Offset(
+                    (x + dashWidth).coerceAtMost(size.width),
+                    0f,
+                ),
+                strokeWidth = strokeWidth,
+            )
+            x += dashWidth + dashGap
+        }
+    },
+)

--- a/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/detail/BookmarkDetailSideEffect.kt
+++ b/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/detail/BookmarkDetailSideEffect.kt
@@ -1,0 +1,8 @@
+package com.phase.bookpin.bookmark.detail
+
+sealed interface BookmarkDetailSideEffect {
+    data class ShowSnackbar(
+        val message: String,
+    ) : BookmarkDetailSideEffect
+    data object NavigateBack : BookmarkDetailSideEffect
+}

--- a/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/detail/BookmarkDetailState.kt
+++ b/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/detail/BookmarkDetailState.kt
@@ -1,0 +1,6 @@
+package com.phase.bookpin.bookmark.detail
+
+data class BookmarkDetailState(
+    val isLoading: Boolean = false,
+    val showDeleteDialog: Boolean = false,
+)

--- a/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/detail/BookmarkDetailViewModel.kt
+++ b/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/detail/BookmarkDetailViewModel.kt
@@ -1,0 +1,41 @@
+package com.phase.bookpin.bookmark.detail
+
+import androidx.lifecycle.viewModelScope
+import com.phase.bookpin.common.BaseViewModel
+import com.phase.bookpin.domain.book.BookRepository
+import kotlinx.coroutines.launch
+
+class BookmarkDetailViewModel(
+    private val bookRepository: BookRepository,
+) : BaseViewModel<BookmarkDetailState, BookmarkDetailSideEffect>() {
+    override fun createInitialState(): BookmarkDetailState = BookmarkDetailState()
+
+    fun onDeleteClick() {
+        reduce { copy(showDeleteDialog = true) }
+    }
+
+    fun onDeleteDismiss() {
+        reduce { copy(showDeleteDialog = false) }
+    }
+
+    fun onDeleteConfirm(bookId: Long, bookmarkId: Long) {
+        reduce { copy(showDeleteDialog = false) }
+        if (uiState.value.isLoading) return
+        viewModelScope.launch {
+            reduce { copy(isLoading = true) }
+            bookRepository
+                .deleteBookmark(bookId, bookmarkId)
+                .onSuccess {
+                    reduce { copy(isLoading = false) }
+                    postSideEffect(BookmarkDetailSideEffect.NavigateBack)
+                }.onFailure { error ->
+                    reduce { copy(isLoading = false) }
+                    postSideEffect(
+                        BookmarkDetailSideEffect.ShowSnackbar(
+                            error.message ?: "오류가 발생했습니다.",
+                        ),
+                    )
+                }
+        }
+    }
+}

--- a/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/di/BookDetailModule.kt
+++ b/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/di/BookDetailModule.kt
@@ -2,6 +2,7 @@ package com.phase.bookpin.bookmark.di
 
 import com.phase.bookpin.bookmark.add.AddBookmarkViewModel
 import com.phase.bookpin.bookmark.detail.BookDetailViewModel
+import com.phase.bookpin.bookmark.detail.BookmarkDetailViewModel
 import org.koin.core.module.dsl.viewModelOf
 import org.koin.dsl.module
 
@@ -9,4 +10,5 @@ val bookDetailModule = module {
     includes(bookmarkPlatformModule)
     viewModelOf(::BookDetailViewModel)
     viewModelOf(::AddBookmarkViewModel)
+    viewModelOf(::BookmarkDetailViewModel)
 }

--- a/feature/home/src/commonMain/kotlin/com/phase/bookpin/home/component/CurrentReadingCard.kt
+++ b/feature/home/src/commonMain/kotlin/com/phase/bookpin/home/component/CurrentReadingCard.kt
@@ -11,28 +11,22 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import bookpin.home.generated.resources.Res
-import bookpin.home.generated.resources.bookmark
-import bookpin.home.generated.resources.cd_bookmark
 import bookpin.home.generated.resources.leave_bookmark
 import coil3.compose.AsyncImage
 import com.phase.bookpin.designsystem.BookPinTheme
 import com.phase.bookpin.model.book.BookItem
-import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 
 @Composable
@@ -83,44 +77,11 @@ internal fun CurrentlyReadingCard(
 
                 Spacer(modifier = Modifier.height(4.dp))
 
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(6.dp),
-                ) {
-                    Text(
-                        text = bookItem.author,
-                        style = BookPinTheme.typography.titleSmall,
-                        color = BookPinTheme.colors.textSecondary,
-                    )
-
-                    Box(
-                        modifier = Modifier
-                            .size(4.dp)
-                            .background(
-                                color = BookPinTheme.colors.borderDefault,
-                                shape = CircleShape,
-                            ),
-                    )
-
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(4.dp),
-                        modifier = Modifier.padding(start = 4.dp),
-                    ) {
-                        Icon(
-                            painter = painterResource(Res.drawable.bookmark),
-                            contentDescription = stringResource(Res.string.cd_bookmark),
-                            modifier = Modifier.size(14.dp),
-                            tint = Color.Unspecified,
-                        )
-
-                        Text(
-                            text = "${bookItem.bookmarkCount}",
-                            style = BookPinTheme.typography.labelMedium,
-                            color = BookPinTheme.colors.textPrimary.copy(alpha = 0.8f),
-                        )
-                    }
-                }
+                Text(
+                    text = bookItem.author,
+                    style = BookPinTheme.typography.titleSmall,
+                    color = BookPinTheme.colors.textSecondary,
+                )
 
                 Spacer(modifier = Modifier.height(16.dp))
 

--- a/feature/search/src/commonMain/kotlin/com/phase/bookpin/search/preview/BookPreviewScreen.kt
+++ b/feature/search/src/commonMain/kotlin/com/phase/bookpin/search/preview/BookPreviewScreen.kt
@@ -3,7 +3,6 @@ package com.phase.bookpin.search.preview
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
@@ -28,7 +27,9 @@ import com.phase.bookpin.common.extensions.collectSideEffect
 import com.phase.bookpin.common.extensions.noRippleClickable
 import com.phase.bookpin.common.snackbar.LocalSnackbarHost
 import com.phase.bookpin.designsystem.BookPinTheme
+import com.phase.bookpin.designsystem.component.BPCloseButton
 import com.phase.bookpin.designsystem.component.BPTextField
+import com.phase.bookpin.designsystem.component.BPTopBar
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.viewmodel.koinViewModel
@@ -69,9 +70,22 @@ fun BookPreviewScreen(
 
     Scaffold(
         topBar = {
-            BookPreviewTopBar(
-                onBackClick = viewModel::onBackClick,
-                onCloseClick = viewModel::onCloseClick,
+            BPTopBar(
+                title = stringResource(Res.string.book_preview_title),
+                navigationIcon = {
+                    IconButton(
+                        onClick = viewModel::onBackClick,
+                        modifier = Modifier.size(36.dp),
+                    ) {
+                        Icon(
+                            painter = painterResource(Res.drawable.ic_arrow_back),
+                            contentDescription = stringResource(Res.string.cd_back),
+                            modifier = Modifier.size(20.dp),
+                            tint = BookPinTheme.colors.iconDefault,
+                        )
+                    }
+                },
+                actions = { BPCloseButton(onClick = viewModel::onCloseClick) },
             )
         },
         bottomBar = {
@@ -122,60 +136,6 @@ fun BookPreviewScreen(
             )
 
             Spacer(modifier = Modifier.height(24.dp))
-        }
-    }
-}
-
-@Composable
-private fun BookPreviewTopBar(
-    onBackClick: () -> Unit,
-    onCloseClick: () -> Unit,
-) {
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 16.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.SpaceBetween,
-    ) {
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(12.dp),
-        ) {
-            IconButton(
-                onClick = onBackClick,
-                modifier = Modifier.size(40.dp),
-            ) {
-                Icon(
-                    painter = painterResource(Res.drawable.ic_arrow_back),
-                    contentDescription = stringResource(Res.string.cd_back),
-                    modifier = Modifier.size(24.dp),
-                    tint = BookPinTheme.colors.iconDefault,
-                )
-            }
-
-            Text(
-                text = stringResource(Res.string.book_preview_title),
-                style = BookPinTheme.typography.headlineMedium,
-                color = BookPinTheme.colors.textPrimary,
-            )
-        }
-
-        IconButton(
-            onClick = onCloseClick,
-            modifier = Modifier
-                .size(40.dp)
-                .background(
-                    color = BookPinTheme.colors.bgSurface,
-                    shape = CircleShape,
-                ),
-        ) {
-            Icon(
-                painter = painterResource(Res.drawable.ic_close),
-                contentDescription = stringResource(Res.string.cd_close),
-                modifier = Modifier.size(24.dp),
-                tint = BookPinTheme.colors.iconDefault,
-            )
         }
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,11 +36,14 @@ ktor = "3.4.0"
 koin = "4.1.1"
 coil = "3.3.0"
 firebase = "2.4.0"
+firebase-bom = "33.12.0"
 kermit = "2.0.8"
 junitVersion = "1.3.0"
 espressoCore = "3.7.0"
 material = "1.13.0"
 ktlint = "14.0.1"
+google-services = "4.4.2"
+firebase-crashlytics-gradle = "3.0.3"
 kotlinStdlib = "2.3.0"
 runner = "1.7.0"
 core = "1.7.0"
@@ -89,6 +92,7 @@ compose-gradle = { group = "org.jetbrains.compose", name = "compose-gradle-plugi
 compose-compiler-gradle = { group = "org.jetbrains.kotlin", name = "compose-compiler-gradle-plugin", version.ref = "kotlin" }
 
 # ThirdParty
+firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebase-bom" }
 firebase-analytics = { module = "dev.gitlive:firebase-analytics", version.ref = "firebase" }
 firebase-crashlytics = { module = "dev.gitlive:firebase-crashlytics", version.ref = "firebase"  }
 
@@ -157,3 +161,5 @@ bookpin-kotlin-serialization = { id = "com.phase.bookpin.serialization", version
 bookpin-compose = { id = "com.phase.bookpin.compose", version = "unspecified" }
 android-lint = { id = "com.android.lint", version.ref = "agp" }
 build-konfig = { id = "com.codingfeline.buildkonfig", version.ref = "buildKonfig" }
+googleServices = { id = "com.google.gms.google-services", version.ref = "google-services" }
+firebaseCrashlyticsPlugin = { id = "com.google.firebase.crashlytics", version.ref = "firebase-crashlytics-gradle" }

--- a/model/src/commonMain/kotlin/com/phase/bookpin/model/book/Bookmark.kt
+++ b/model/src/commonMain/kotlin/com/phase/bookpin/model/book/Bookmark.kt
@@ -7,4 +7,5 @@ data class Bookmark(
     val extractedText: String,
     val note: String,
     val imageUrl: String,
+    val createdAt: String,
 )


### PR DESCRIPTION
## 1. 📄 관련된 이슈 및 소개
- 관련 이슈: closes #56
- 소개: BookDetailScreen에서 텍스트/사진 책갈피를 클릭하면 이동하는 책갈피 상세 조회 화면을 구현합니다.

## 2. 🔥 변경된 점
- `Bookmark` 모델에 `createdAt` 필드 추가 및 `BookmarkResponse` 매퍼 수정
- `BookmarkDetailRoute` 네비게이션 Route 정의 및 serializer 등록
- `BookmarkDetailScreen` 신규 생성 (책 정보, 사진(조건부), 책 내용, 개인 메모 섹션)
- `BPTopBar` 디자인 시스템 컴포넌트에 navigationIcon/actions 슬롯 오버로드 추가
- `BookDetailScreen`의 `TextBookmarkItem`, `PhotoBookmarkItem`에 클릭 이벤트 연결
- `BookDetailSideEffect.NavigateToBookmarkDetail` 추가 및 ViewModel 연결
- `BookPinNavHost`, `BookPinApp`에 네비게이션 연결
- 삭제 아이콘(`ic_delete.xml`) 및 문자열 리소스 추가
- 삭제 버튼은 UI만 배치, 클릭 시 "준비 중" 스낵바 표시

## 3. ✅ 필수 체크 사항
- [ ] 빌드 확인
- [ ] 테스트 확인
- [ ] 코드 리뷰 요청

## 4. 📸 작업물 사진 공유(선택)

## 5. 💡 알게된 혹은 궁금한 사항
- 삭제 API는 별도 이슈로 처리 예정