### PR TITLE
#60 : Firebase Analytics & Crashlytics 연동 (Android)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,9 @@ jobs:
           echo "BASE_URL=${{ secrets.BASE_URL }}" >> local.properties
           echo "KAKAO_NATIVE_APP_KEY=${{ secrets.KAKAO_NATIVE_APP_KEY }}" >> local.properties
 
+      - name: Create google-services.json
+        run: echo '${{ secrets.GOOGLE_SERVICES_JSON }}' > android-app/google-services.json
+
       # 1) 빌드 테스트
       - name: Build (assembleDebug)
         run: ./gradlew assembleDebug --no-daemon --stacktrace

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ captures
 !*.xcworkspace/contents.xcworkspacedata
 **/xcshareddata/WorkspaceSettings.xcsettings
 node_modules/
+google-services.json

--- a/android-app/build.gradle.kts
+++ b/android-app/build.gradle.kts
@@ -9,6 +9,10 @@ plugins {
 android {
     namespace = "com.phase.bookpin.androidapp"
 
+    defaultConfig {
+        applicationId = "com.phase.bookpin"
+    }
+
     buildFeatures {
         buildConfig = true
         compose = true

--- a/android-app/build.gradle.kts
+++ b/android-app/build.gradle.kts
@@ -2,6 +2,8 @@ plugins {
     alias(libs.plugins.bookpin.android.application)
     alias(libs.plugins.composeCompiler)
     alias(libs.plugins.bookpin.ktlint)
+    alias(libs.plugins.googleServices)
+    alias(libs.plugins.firebaseCrashlyticsPlugin)
 }
 
 android {
@@ -27,6 +29,10 @@ dependencies {
 
     implementation(libs.koin.core)
     implementation(libs.koin.android)
+
+    implementation(platform(libs.firebase.bom))
+    implementation(libs.firebase.analytics)
+    implementation(libs.firebase.crashlytics)
 
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,4 +12,6 @@ plugins {
     alias(libs.plugins.ktlint)
     alias(libs.plugins.android.lint) apply false
     alias(libs.plugins.build.konfig) apply false
+    alias(libs.plugins.googleServices) apply false
+    alias(libs.plugins.firebaseCrashlyticsPlugin) apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,11 +36,14 @@ ktor = "3.4.0"
 koin = "4.1.1"
 coil = "3.3.0"
 firebase = "2.4.0"
+firebase-bom = "33.12.0"
 kermit = "2.0.8"
 junitVersion = "1.3.0"
 espressoCore = "3.7.0"
 material = "1.13.0"
 ktlint = "14.0.1"
+google-services = "4.4.2"
+firebase-crashlytics-gradle = "3.0.3"
 kotlinStdlib = "2.3.0"
 runner = "1.7.0"
 core = "1.7.0"
@@ -89,6 +92,7 @@ compose-gradle = { group = "org.jetbrains.compose", name = "compose-gradle-plugi
 compose-compiler-gradle = { group = "org.jetbrains.kotlin", name = "compose-compiler-gradle-plugin", version.ref = "kotlin" }
 
 # ThirdParty
+firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebase-bom" }
 firebase-analytics = { module = "dev.gitlive:firebase-analytics", version.ref = "firebase" }
 firebase-crashlytics = { module = "dev.gitlive:firebase-crashlytics", version.ref = "firebase"  }
 
@@ -157,3 +161,5 @@ bookpin-kotlin-serialization = { id = "com.phase.bookpin.serialization", version
 bookpin-compose = { id = "com.phase.bookpin.compose", version = "unspecified" }
 android-lint = { id = "com.android.lint", version.ref = "agp" }
 build-konfig = { id = "com.codingfeline.buildkonfig", version.ref = "buildKonfig" }
+googleServices = { id = "com.google.gms.google-services", version.ref = "google-services" }
+firebaseCrashlyticsPlugin = { id = "com.google.firebase.crashlytics", version.ref = "firebase-crashlytics-gradle" }


### PR DESCRIPTION
## 1. 📄 관련된 이슈 및 소개
- 관련 이슈: closes #60
- 소개: Android에 Firebase Analytics와 Crashlytics를 연동합니다.

## 2. 🔥 변경된 점
- `libs.versions.toml`에 Google Services, Firebase Crashlytics Gradle 플러그인 및 Firebase BOM 버전 추가
- 루트 `build.gradle.kts`에 플러그인 `apply false` 선언
- `android-app/build.gradle.kts`에 플러그인 적용 및 Firebase 의존성 추가
- `.gitignore`에 `google-services.json` 추가
- CI에 `GOOGLE_SERVICES_JSON` secret으로부터 설정 파일 생성 step 추가

## 3. ✅ 필수 체크 사항
- [ ] 빌드 확인
- [ ] 테스트 확인
- [ ] 코드 리뷰 요청

## 4. 📸 작업물 사진 공유(선택)
N/A

## 5. 💡 알게된 혹은 궁금한 사항
- `google-services.json`은 gitignore 처리하고 GitHub Secrets(`GOOGLE_SERVICES_JSON`)에 파일 내용 전체를 등록해야 합니다.
- GitLive Firebase 라이브러리(`dev.gitlive:firebase-*`)는 네이티브 Firebase SDK에 의존하므로 Firebase BOM을 함께 추가했습니다.