### PR TITLE
#62 : 네비게이션 popBackStack 전환으로 홈/상세 화면 상태 유지

### DIFF
--- a/compose-app/src/commonMain/kotlin/com/phase/bookpin/BookPinApp.kt
+++ b/compose-app/src/commonMain/kotlin/com/phase/bookpin/BookPinApp.kt
@@ -76,6 +76,15 @@ fun BookPinApp(
                         backStack.clear()
                         backStack.add(HomeRoute)
                     },
+                    onPopBackToHome = {
+                        while (backStack.lastOrNull() !is HomeRoute) {
+                            backStack.removeLastOrNull() ?: break
+                        }
+                    },
+                    onPopBackToBookDetail = {
+                        backStack.removeLastOrNull() // AddBookmark
+                        backStack.removeLastOrNull() // BookmarkTypeSelect
+                    },
                     onNavigateToSearch = {
                         backStack.add(SearchRoute)
                     },

--- a/compose-app/src/commonMain/kotlin/com/phase/bookpin/BookPinApp.kt
+++ b/compose-app/src/commonMain/kotlin/com/phase/bookpin/BookPinApp.kt
@@ -82,8 +82,9 @@ fun BookPinApp(
                         }
                     },
                     onPopBackToBookDetail = {
-                        backStack.removeLastOrNull() // AddBookmark
-                        backStack.removeLastOrNull() // BookmarkTypeSelect
+                        while (backStack.lastOrNull() !is BookDetailRoute) {
+                            backStack.removeLastOrNull() ?: break
+                        }
                     },
                     onNavigateToSearch = {
                         backStack.add(SearchRoute)

--- a/compose-app/src/commonMain/kotlin/com/phase/bookpin/navigation/BookPinNavHost.kt
+++ b/compose-app/src/commonMain/kotlin/com/phase/bookpin/navigation/BookPinNavHost.kt
@@ -19,6 +19,7 @@ import com.phase.bookpin.splash.SplashScreen
 fun BookPinNavHost(
     backStack: NavBackStack<NavKey>,
     onNavigateToHome: () -> Unit,
+    onPopBackToHome: () -> Unit,
     onNavigateToSearch: () -> Unit,
     onNavigateToBookDetail: (Long) -> Unit,
     onNavigateToBookmarkTypeSelect: (Long) -> Unit,
@@ -26,6 +27,7 @@ fun BookPinNavHost(
     onNavigateToBookPreview: (BookPreviewRoute) -> Unit,
     onNavigateToSettings: () -> Unit,
     onNavigateBack: () -> Unit,
+    onPopBackToBookDetail: () -> Unit,
     onLogout: () -> Unit,
 ) {
     NavDisplay(
@@ -71,8 +73,8 @@ fun BookPinNavHost(
                     imageUrl = route.imageUrl,
                     isbn = route.isbn,
                     onNavigateBack = onNavigateBack,
-                    onNavigateClose = onNavigateBack,
-                    onNavigateToHome = onNavigateToHome,
+                    onNavigateClose = onPopBackToHome,
+                    onNavigateToHome = onPopBackToHome,
                 )
             }
 
@@ -81,7 +83,7 @@ fun BookPinNavHost(
                     bookId = route.bookId,
                     onNavigateBack = onNavigateBack,
                     onNavigateToAddBookmark = { onNavigateToBookmarkTypeSelect(route.bookId) },
-                    onNavigateToHome = onNavigateToHome,
+                    onNavigateToHome = onPopBackToHome,
                 )
             }
 
@@ -99,6 +101,7 @@ fun BookPinNavHost(
                     bookId = route.bookId,
                     bookmarkType = route.bookmarkType,
                     onNavigateBack = onNavigateBack,
+                    onPopBackToBookDetail = onPopBackToBookDetail,
                 )
             }
 

--- a/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/add/AddBookmarkScreen.kt
+++ b/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/add/AddBookmarkScreen.kt
@@ -41,6 +41,7 @@ fun AddBookmarkScreen(
     bookId: Long,
     bookmarkType: BookmarkType,
     onNavigateBack: () -> Unit,
+    onPopBackToBookDetail: () -> Unit,
 ) {
     val viewModel: AddBookmarkViewModel = koinViewModel()
     val state by viewModel.uiState.collectAsStateWithLifecycle()
@@ -81,7 +82,7 @@ fun AddBookmarkScreen(
                 snackbarHost.showSnackbar(it.message)
             }
             AddBookmarkSideEffect.NavigateBack -> onNavigateBack()
-            AddBookmarkSideEffect.BookmarkSaved -> onNavigateBack()
+            AddBookmarkSideEffect.BookmarkSaved -> onPopBackToBookDetail()
         }
     }
 


### PR DESCRIPTION
## 1. 📄 관련된 이슈 및 소개
- 관련 이슈: closes #62
- 소개: 작업 완료 후 홈으로 돌아가는 플로우에서 `backStack.clear() + add(HomeRoute)` 대신 `popBackStack`으로 기존 화면까지 되돌아가도록 변경하여 홈 화면 상태 유실을 방지합니다.

## 2. 🔥 변경된 점
- `BookPinApp.kt`: `onPopBackToHome`(HomeRoute까지 pop), `onPopBackToBookDetail`(AddBookmark + BookmarkTypeSelect 2개 pop) 람다 추가
- `BookPinNavHost.kt`: BookPreviewRoute의 `onNavigateClose`/`onNavigateToHome`, BookDetailRoute의 `onNavigateToHome`을 `onPopBackToHome`으로 연결 변경. AddBookmarkRoute에 `onPopBackToBookDetail` 연결
- `AddBookmarkScreen.kt`: `onPopBackToBookDetail` 콜백 추가, `BookmarkSaved` side effect에서 호출하여 BookDetail로 정확히 복귀

## 3. ✅ 필수 체크 사항
- [x] 빌드 확인
- [ ] 테스트 확인
- [ ] 코드 리뷰 요청

## 4. 📸 작업물 사진 공유(선택)

## 5. 💡 알게된 혹은 궁금한 사항
- SplashScreen → Home 플로우는 기존 `clear + add` 방식 유지 (스택에 HomeRoute가 없으므로)
- BookPreview의 X 버튼(onNavigateClose)도 `onPopBackToHome`으로 변경하여 Search + BookPreview 모두 pop