### PR TITLE
#67 : UI/UX 개선 - 완독 UI, 페이지 빈값 처리, 설정 화면 정리

### DIFF
--- a/compose-app/src/commonMain/kotlin/com/phase/bookpin/BookPinApp.kt
+++ b/compose-app/src/commonMain/kotlin/com/phase/bookpin/BookPinApp.kt
@@ -82,6 +82,9 @@ fun BookPinApp(
                     onNavigateToBookDetail = { bookId ->
                         backStack.add(BookDetailRoute(bookId))
                     },
+                    onNavigateToBookmarkDetail = { route ->
+                        backStack.add(route)
+                    },
                     onNavigateToBookmarkTypeSelect = { bookId ->
                         backStack.add(BookmarkTypeSelectRoute(bookId))
                     },

--- a/compose-app/src/commonMain/kotlin/com/phase/bookpin/BookPinApp.kt
+++ b/compose-app/src/commonMain/kotlin/com/phase/bookpin/BookPinApp.kt
@@ -100,6 +100,11 @@ fun BookPinApp(
                     onNavigateBack = {
                         backStack.removeLastOrNull()
                     },
+                    onNavigateBackToBookDetail = {
+                        while (backStack.lastOrNull() !is BookDetailRoute) {
+                            backStack.removeLastOrNull() ?: break
+                        }
+                    },
                     onLogout = {
                         backStack.clear()
                         backStack.add(SplashRoute)

--- a/compose-app/src/commonMain/kotlin/com/phase/bookpin/BookPinApp.kt
+++ b/compose-app/src/commonMain/kotlin/com/phase/bookpin/BookPinApp.kt
@@ -110,11 +110,6 @@ fun BookPinApp(
                     onNavigateBack = {
                         backStack.removeLastOrNull()
                     },
-                    onNavigateBackToBookDetail = {
-                        while (backStack.lastOrNull() !is BookDetailRoute) {
-                            backStack.removeLastOrNull() ?: break
-                        }
-                    },
                     onLogout = {
                         backStack.clear()
                         backStack.add(SplashRoute)

--- a/compose-app/src/commonMain/kotlin/com/phase/bookpin/navigation/BookPinNavHost.kt
+++ b/compose-app/src/commonMain/kotlin/com/phase/bookpin/navigation/BookPinNavHost.kt
@@ -8,6 +8,7 @@ import androidx.navigation3.ui.NavDisplay
 import com.phase.bookpin.bookmark.add.AddBookmarkScreen
 import com.phase.bookpin.bookmark.add.BookmarkTypeSelectScreen
 import com.phase.bookpin.bookmark.detail.BookDetailScreen
+import com.phase.bookpin.bookmark.detail.BookmarkDetailScreen
 import com.phase.bookpin.home.HomeScreen
 import com.phase.bookpin.model.bookmark.BookmarkType
 import com.phase.bookpin.search.SearchScreen
@@ -23,6 +24,7 @@ fun BookPinNavHost(
     onNavigateToBookDetail: (Long) -> Unit,
     onNavigateToBookmarkTypeSelect: (Long) -> Unit,
     onNavigateToAddBookmark: (Long, BookmarkType) -> Unit,
+    onNavigateToBookmarkDetail: (BookmarkDetailRoute) -> Unit = {},
     onNavigateToBookPreview: (BookPreviewRoute) -> Unit,
     onNavigateToSettings: () -> Unit,
     onNavigateBack: () -> Unit,
@@ -81,6 +83,35 @@ fun BookPinNavHost(
                     bookId = route.bookId,
                     onNavigateBack = onNavigateBack,
                     onNavigateToAddBookmark = { onNavigateToBookmarkTypeSelect(route.bookId) },
+                    onNavigateToBookmarkDetail = { book, bookmark ->
+                        onNavigateToBookmarkDetail(
+                            BookmarkDetailRoute(
+                                bookTitle = book.title,
+                                bookAuthor = book.author,
+                                bookImageUrl = book.imageUrl,
+                                bookmarkId = bookmark.id,
+                                pageNumber = bookmark.pageNumber,
+                                extractedText = bookmark.extractedText,
+                                note = bookmark.note,
+                                imageUrl = bookmark.imageUrl,
+                                createdAt = bookmark.createdAt,
+                            ),
+                        )
+                    },
+                )
+            }
+
+            entry<BookmarkDetailRoute> { route ->
+                BookmarkDetailScreen(
+                    bookTitle = route.bookTitle,
+                    bookAuthor = route.bookAuthor,
+                    bookImageUrl = route.bookImageUrl,
+                    pageNumber = route.pageNumber,
+                    extractedText = route.extractedText,
+                    note = route.note,
+                    imageUrl = route.imageUrl,
+                    createdAt = route.createdAt,
+                    onNavigateBack = onNavigateBack,
                 )
             }
 

--- a/compose-app/src/commonMain/kotlin/com/phase/bookpin/navigation/BookPinNavHost.kt
+++ b/compose-app/src/commonMain/kotlin/com/phase/bookpin/navigation/BookPinNavHost.kt
@@ -87,6 +87,7 @@ fun BookPinNavHost(
                     onNavigateToBookmarkDetail = { book, bookmark ->
                         onNavigateToBookmarkDetail(
                             BookmarkDetailRoute(
+                                bookId = book.id,
                                 bookTitle = book.title,
                                 bookAuthor = book.author,
                                 bookImageUrl = book.imageUrl,
@@ -104,6 +105,8 @@ fun BookPinNavHost(
 
             entry<BookmarkDetailRoute> { route ->
                 BookmarkDetailScreen(
+                    bookId = route.bookId,
+                    bookmarkId = route.bookmarkId,
                     bookTitle = route.bookTitle,
                     bookAuthor = route.bookAuthor,
                     bookImageUrl = route.bookImageUrl,

--- a/compose-app/src/commonMain/kotlin/com/phase/bookpin/navigation/BookPinNavHost.kt
+++ b/compose-app/src/commonMain/kotlin/com/phase/bookpin/navigation/BookPinNavHost.kt
@@ -28,6 +28,7 @@ fun BookPinNavHost(
     onNavigateToBookPreview: (BookPreviewRoute) -> Unit,
     onNavigateToSettings: () -> Unit,
     onNavigateBack: () -> Unit,
+    onNavigateBackToBookDetail: () -> Unit,
     onLogout: () -> Unit,
 ) {
     NavDisplay(
@@ -133,6 +134,7 @@ fun BookPinNavHost(
                     bookId = route.bookId,
                     bookmarkType = route.bookmarkType,
                     onNavigateBack = onNavigateBack,
+                    onBookmarkSaved = onNavigateBackToBookDetail,
                 )
             }
 

--- a/compose-app/src/commonMain/kotlin/com/phase/bookpin/navigation/Route.kt
+++ b/compose-app/src/commonMain/kotlin/com/phase/bookpin/navigation/Route.kt
@@ -35,6 +35,19 @@ data class AddBookmarkRoute(
 ) : NavKey
 
 @Serializable
+data class BookmarkDetailRoute(
+    val bookTitle: String,
+    val bookAuthor: String,
+    val bookImageUrl: String,
+    val bookmarkId: Long,
+    val pageNumber: Int,
+    val extractedText: String,
+    val note: String,
+    val imageUrl: String,
+    val createdAt: String,
+) : NavKey
+
+@Serializable
 data class BookPreviewRoute(
     val title: String = "",
     val author: String = "",
@@ -52,6 +65,7 @@ val navSerializersModule = SerializersModule {
         subclass(BookmarkTypeSelectRoute::class, BookmarkTypeSelectRoute.serializer())
         subclass(AddBookmarkRoute::class, AddBookmarkRoute.serializer())
         subclass(SettingsRoute::class, SettingsRoute.serializer())
+        subclass(BookmarkDetailRoute::class, BookmarkDetailRoute.serializer())
         subclass(BookPreviewRoute::class, BookPreviewRoute.serializer())
     }
 }

--- a/compose-app/src/commonMain/kotlin/com/phase/bookpin/navigation/Route.kt
+++ b/compose-app/src/commonMain/kotlin/com/phase/bookpin/navigation/Route.kt
@@ -36,6 +36,7 @@ data class AddBookmarkRoute(
 
 @Serializable
 data class BookmarkDetailRoute(
+    val bookId: Long,
     val bookTitle: String,
     val bookAuthor: String,
     val bookImageUrl: String,

--- a/compose-app/src/commonMain/kotlin/com/phase/bookpin/state/RootViewModel.kt
+++ b/compose-app/src/commonMain/kotlin/com/phase/bookpin/state/RootViewModel.kt
@@ -23,7 +23,6 @@ class RootViewModel(
                     SessionEvent.InvalidRefreshToken,
                     -> {
                         sessionRepository.clearSession()
-                        postSideEffect(RootSideEffect.ShowSnackbar("세션이 만료되었습니다. 다시 로그인해주세요."))
                         postSideEffect(RootSideEffect.NavigateToSplash)
                     }
                 }

--- a/core/data-api/src/commonMain/kotlin/com/phase/bookpin/data/api/book/AddBookmarkRequest.kt
+++ b/core/data-api/src/commonMain/kotlin/com/phase/bookpin/data/api/book/AddBookmarkRequest.kt
@@ -3,9 +3,9 @@ package com.phase.bookpin.data.api.book
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class CreateBookmarkRequest(
+data class AddBookmarkRequest(
     val pageNumber: Int,
     val extractedText: String,
     val note: String,
-    val imageUrl: String,
+    val imageUrl: String?,
 )

--- a/core/data-api/src/commonMain/kotlin/com/phase/bookpin/data/api/book/BookDetailResponse.kt
+++ b/core/data-api/src/commonMain/kotlin/com/phase/bookpin/data/api/book/BookDetailResponse.kt
@@ -12,7 +12,6 @@ data class BookDetailResponse(
     val totalPage: Int = 0,
     val currentPage: Int = 0,
     val progress: Double = 0.0,
-    val isCompleted: Boolean = false,
     val createdAt: String = "",
 ) {
     fun toBookDetail(): BookDetail = BookDetail(
@@ -23,6 +22,6 @@ data class BookDetailResponse(
         totalPage = totalPage,
         currentPage = currentPage,
         progress = progress,
-        isCompleted = isCompleted,
+        isCompleted = totalPage == currentPage,
     )
 }

--- a/core/data-api/src/commonMain/kotlin/com/phase/bookpin/data/api/book/BookRemoteDataSource.kt
+++ b/core/data-api/src/commonMain/kotlin/com/phase/bookpin/data/api/book/BookRemoteDataSource.kt
@@ -14,4 +14,6 @@ interface BookRemoteDataSource {
     suspend fun createBookmark(bookId: Long, request: CreateBookmarkRequest): Result<BookmarkResponse>
 
     suspend fun completeBook(bookId: Long): Result<BookDetailResponse>
+
+    suspend fun deleteBookmark(bookId: Long, bookmarkId: Long): Result<Unit>
 }

--- a/core/data-api/src/commonMain/kotlin/com/phase/bookpin/data/api/book/BookRemoteDataSource.kt
+++ b/core/data-api/src/commonMain/kotlin/com/phase/bookpin/data/api/book/BookRemoteDataSource.kt
@@ -11,7 +11,7 @@ interface BookRemoteDataSource {
 
     suspend fun getPhotoBookmarks(bookId: Long): Result<List<BookmarkResponse>>
 
-    suspend fun createBookmark(bookId: Long, request: CreateBookmarkRequest): Result<BookmarkResponse>
+    suspend fun addBookmark(bookId: Long, request: AddBookmarkRequest): Result<BookmarkResponse>
 
     suspend fun completeBook(bookId: Long): Result<BookDetailResponse>
 

--- a/core/data-api/src/commonMain/kotlin/com/phase/bookpin/data/api/book/BookmarkResponse.kt
+++ b/core/data-api/src/commonMain/kotlin/com/phase/bookpin/data/api/book/BookmarkResponse.kt
@@ -20,5 +20,6 @@ data class BookmarkResponse(
         extractedText = extractedText,
         note = note,
         imageUrl = imageUrl,
+        createdAt = createdAt,
     )
 }

--- a/core/data-remote/src/commonMain/kotlin/com/phase/bookpin/data/remote/book/BookRemoteDataSourceImpl.kt
+++ b/core/data-remote/src/commonMain/kotlin/com/phase/bookpin/data/remote/book/BookRemoteDataSourceImpl.kt
@@ -74,4 +74,12 @@ class BookRemoteDataSourceImpl(
                 path("api/v1/books/$bookId/complete")
             }
         }
+
+    override suspend fun deleteBookmark(bookId: Long, bookmarkId: Long): Result<Unit> =
+        httpClient.safeRequest {
+            url {
+                method = HttpMethod.Delete
+                path("api/v1/books/$bookId/bookmarks/$bookmarkId")
+            }
+        }
 }

--- a/core/data-remote/src/commonMain/kotlin/com/phase/bookpin/data/remote/book/BookRemoteDataSourceImpl.kt
+++ b/core/data-remote/src/commonMain/kotlin/com/phase/bookpin/data/remote/book/BookRemoteDataSourceImpl.kt
@@ -4,7 +4,7 @@ import com.phase.bookpin.data.api.book.BookDetailResponse
 import com.phase.bookpin.data.api.book.BookItemResponse
 import com.phase.bookpin.data.api.book.BookRemoteDataSource
 import com.phase.bookpin.data.api.book.BookmarkResponse
-import com.phase.bookpin.data.api.book.CreateBookmarkRequest
+import com.phase.bookpin.data.api.book.AddBookmarkRequest
 import com.phase.bookpin.data.api.book.LatestBookmarkResponse
 import com.phase.bookpin.data.remote.client.safeRequest
 import io.ktor.client.HttpClient
@@ -55,9 +55,9 @@ class BookRemoteDataSourceImpl(
             }
         }
 
-    override suspend fun createBookmark(
+    override suspend fun addBookmark(
         bookId: Long,
-        request: CreateBookmarkRequest,
+        request: AddBookmarkRequest,
     ): Result<BookmarkResponse> =
         httpClient.safeRequest {
             url {

--- a/core/data-remote/src/commonMain/kotlin/com/phase/bookpin/data/remote/client/ClientModule.kt
+++ b/core/data-remote/src/commonMain/kotlin/com/phase/bookpin/data/remote/client/ClientModule.kt
@@ -114,11 +114,14 @@ private suspend fun refreshBearerTokens(
         local.saveString(DataStoreKey.ACCESS_TOKEN, response.accessToken)
         local.saveString(DataStoreKey.REFRESH_TOKEN, response.refreshToken)
         BearerTokens(response.accessToken, response.refreshToken)
-    }.onFailure { throwable ->
+    }.getOrElse { throwable ->
         if (throwable.shouldReAuthenticateFailure()) {
             listener.onInvalidRefreshToken()
+            null
+        } else {
+            loadBearerTokens(local).getOrNull()
         }
-    }.getOrNull()
+    }
 }
 
 internal fun createRefreshHttpClient(logger: KermitLogger): HttpClient = createPlatformHttpClient {

--- a/core/data/src/commonMain/kotlin/com/phase/bookpin/data/auth/SessionRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/com/phase/bookpin/data/auth/SessionRepositoryImpl.kt
@@ -27,8 +27,5 @@ class SessionRepositoryImpl(
         preferenceDataStore.remove(DataStoreKey.ACCESS_TOKEN)
         preferenceDataStore.remove(DataStoreKey.REFRESH_TOKEN)
         preferenceDataStore.remove(DataStoreKey.REFRESH_TOKEN_EXPIRED_AT)
-        preferenceDataStore.remove(DataStoreKey.USER_ID)
-        preferenceDataStore.remove(DataStoreKey.USER_NICKNAME)
-        preferenceDataStore.remove(DataStoreKey.USER_PROFILE_IMAGE_URL)
     }
 }

--- a/core/data/src/commonMain/kotlin/com/phase/bookpin/data/book/BookRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/com/phase/bookpin/data/book/BookRepositoryImpl.kt
@@ -56,4 +56,8 @@ class BookRepositoryImpl(
     override suspend fun completeBook(bookId: Long): Result<BookDetail> {
         return dataSource.completeBook(bookId).mapCatching { it.toBookDetail() }
     }
+
+    override suspend fun deleteBookmark(bookId: Long, bookmarkId: Long): Result<Unit> {
+        return dataSource.deleteBookmark(bookId, bookmarkId)
+    }
 }

--- a/core/data/src/commonMain/kotlin/com/phase/bookpin/data/book/BookRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/com/phase/bookpin/data/book/BookRepositoryImpl.kt
@@ -1,7 +1,7 @@
 package com.phase.bookpin.data.book
 
 import com.phase.bookpin.data.api.book.BookRemoteDataSource
-import com.phase.bookpin.data.api.book.CreateBookmarkRequest
+import com.phase.bookpin.data.api.book.AddBookmarkRequest
 import com.phase.bookpin.domain.book.BookRepository
 import com.phase.bookpin.model.book.BookDetail
 import com.phase.bookpin.model.book.BookItem
@@ -37,20 +37,20 @@ class BookRepositoryImpl(
         }
     }
 
-    override suspend fun createBookmark(
+    override suspend fun addBookmark(
         bookId: Long,
         pageNumber: Int,
         extractedText: String,
         note: String,
-        imageUrl: String,
+        imageUrl: String?,
     ): Result<Bookmark> {
-        val request = CreateBookmarkRequest(
+        val request = AddBookmarkRequest(
             pageNumber = pageNumber,
             extractedText = extractedText,
             note = note,
             imageUrl = imageUrl,
         )
-        return dataSource.createBookmark(bookId, request).mapCatching { it.toBookmark() }
+        return dataSource.addBookmark(bookId, request).mapCatching { it.toBookmark() }
     }
 
     override suspend fun completeBook(bookId: Long): Result<BookDetail> {

--- a/designsystem/src/commonMain/kotlin/com/phase/bookpin/designsystem/component/BPCloseButton.kt
+++ b/designsystem/src/commonMain/kotlin/com/phase/bookpin/designsystem/component/BPCloseButton.kt
@@ -1,0 +1,37 @@
+package com.phase.bookpin.designsystem.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import bookpin.designsystem.generated.resources.Res
+import bookpin.designsystem.generated.resources.ic_close
+import com.phase.bookpin.designsystem.BookPinTheme
+import org.jetbrains.compose.resources.painterResource
+
+@Composable
+fun BPCloseButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    IconButton(
+        onClick = onClick,
+        modifier = modifier
+            .size(36.dp)
+            .background(
+                color = BookPinTheme.colors.bgSurface,
+                shape = CircleShape,
+            ),
+    ) {
+        Icon(
+            painter = painterResource(Res.drawable.ic_close),
+            contentDescription = null,
+            modifier = Modifier.size(18.dp),
+            tint = BookPinTheme.colors.iconDefault,
+        )
+    }
+}

--- a/designsystem/src/commonMain/kotlin/com/phase/bookpin/designsystem/component/BPLoadingScreen.kt
+++ b/designsystem/src/commonMain/kotlin/com/phase/bookpin/designsystem/component/BPLoadingScreen.kt
@@ -14,7 +14,7 @@ fun BPLoadingScreen(modifier: Modifier = Modifier) {
     Box(
         modifier = modifier
             .fillMaxSize()
-            .background(BookPinTheme.colors.bgCanvas),
+            .background(BookPinTheme.colors.bgCanvas.copy(alpha = 0.6f)),
         contentAlignment = Alignment.Center,
     ) {
         CircularProgressIndicator(

--- a/designsystem/src/commonMain/kotlin/com/phase/bookpin/designsystem/component/BPTopBar.kt
+++ b/designsystem/src/commonMain/kotlin/com/phase/bookpin/designsystem/component/BPTopBar.kt
@@ -1,10 +1,6 @@
 package com.phase.bookpin.designsystem.component
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -13,66 +9,42 @@ import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
-import bookpin.designsystem.generated.resources.Res
-import bookpin.designsystem.generated.resources.ic_close
 import com.phase.bookpin.designsystem.BookPinTheme
-import org.jetbrains.compose.resources.painterResource
-
-@Composable
-fun BPTopBar(
-    title: String,
-    onClose: () -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    val borderColor = BookPinTheme.colors.borderSubtle
-
-    Box(
-        modifier = modifier
-            .fillMaxWidth()
-            .drawBottomBorder(borderColor)
-            .padding(horizontal = 16.dp, vertical = 12.dp),
-    ) {
-        Text(
-            text = title,
-            style = BookPinTheme.typography.headlineSmall,
-            color = BookPinTheme.colors.textPrimary,
-            modifier = Modifier.align(Alignment.CenterStart),
-        )
-
-        IconButton(
-            onClick = onClose,
-            modifier = Modifier
-                .size(36.dp)
-                .background(
-                    color = BookPinTheme.colors.bgSurface,
-                    shape = CircleShape,
-                )
-                .align(Alignment.CenterEnd),
-        ) {
-            Icon(
-                painter = painterResource(Res.drawable.ic_close),
-                contentDescription = null,
-                modifier = Modifier.size(18.dp),
-                tint = BookPinTheme.colors.iconDefault,
-            )
-        }
-    }
-}
 
 @Composable
 fun BPTopBar(
     modifier: Modifier = Modifier,
+    title: String? = null,
     navigationIcon: @Composable (() -> Unit)? = null,
     actions: @Composable (RowScope.() -> Unit)? = null,
+    showBottomBorder: Boolean = false,
 ) {
+    val borderModifier = if (showBottomBorder) {
+        modifier.drawBottomBorder(BookPinTheme.colors.borderSubtle)
+    } else {
+        modifier
+    }
+
     Box(
-        modifier = modifier
+        modifier = borderModifier
             .fillMaxWidth()
             .padding(horizontal = 16.dp, vertical = 12.dp),
     ) {
-        if (navigationIcon != null) {
-            Box(modifier = Modifier.align(Alignment.CenterStart)) {
-                navigationIcon()
+        if (navigationIcon != null || title != null) {
+            Row(
+                modifier = Modifier.align(Alignment.CenterStart),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                if (navigationIcon != null) {
+                    navigationIcon()
+                }
+                if (title != null) {
+                    Text(
+                        text = title,
+                        style = BookPinTheme.typography.headlineSmall,
+                        color = BookPinTheme.colors.textPrimary,
+                    )
+                }
             }
         }
 

--- a/designsystem/src/commonMain/kotlin/com/phase/bookpin/designsystem/component/BPTopBar.kt
+++ b/designsystem/src/commonMain/kotlin/com/phase/bookpin/designsystem/component/BPTopBar.kt
@@ -59,6 +59,31 @@ fun BPTopBar(
     }
 }
 
+@Composable
+fun BPTopBar(
+    modifier: Modifier = Modifier,
+    navigationIcon: @Composable (() -> Unit)? = null,
+    actions: @Composable (RowScope.() -> Unit)? = null,
+) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+    ) {
+        if (navigationIcon != null) {
+            Box(modifier = Modifier.align(Alignment.CenterStart)) {
+                navigationIcon()
+            }
+        }
+
+        if (actions != null) {
+            Row(modifier = Modifier.align(Alignment.CenterEnd)) {
+                actions()
+            }
+        }
+    }
+}
+
 private fun Modifier.drawBottomBorder(color: Color): Modifier = this.then(
     Modifier.drawWithContent {
         drawContent()

--- a/domain/src/commonMain/kotlin/com/phase/bookpin/domain/book/BookRepository.kt
+++ b/domain/src/commonMain/kotlin/com/phase/bookpin/domain/book/BookRepository.kt
@@ -16,12 +16,12 @@ interface BookRepository {
 
     suspend fun getPhotoBookmarks(bookId: Long): Result<List<Bookmark>>
 
-    suspend fun createBookmark(
+    suspend fun addBookmark(
         bookId: Long,
         pageNumber: Int,
         extractedText: String,
         note: String,
-        imageUrl: String,
+        imageUrl: String?,
     ): Result<Bookmark>
 
     suspend fun completeBook(bookId: Long): Result<BookDetail>

--- a/domain/src/commonMain/kotlin/com/phase/bookpin/domain/book/BookRepository.kt
+++ b/domain/src/commonMain/kotlin/com/phase/bookpin/domain/book/BookRepository.kt
@@ -25,4 +25,6 @@ interface BookRepository {
     ): Result<Bookmark>
 
     suspend fun completeBook(bookId: Long): Result<BookDetail>
+
+    suspend fun deleteBookmark(bookId: Long, bookmarkId: Long): Result<Unit>
 }

--- a/feature/bookmark/src/commonMain/composeResources/drawable/ic_delete.xml
+++ b/feature/bookmark/src/commonMain/composeResources/drawable/ic_delete.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#000000"
+        android:pathData="M7,21q-0.825,0 -1.412,-0.587Q5,19.825 5,19V6H4V4h5V3h6v1h5v2h-1v13q0,0.825 -0.587,1.413Q17.825,21 17,21ZM17,6H7v13h10ZM9,17h2V8H9Zm4,0h2V8h-2ZM7,6v13Z" />
+</vector>

--- a/feature/bookmark/src/commonMain/composeResources/values/strings.xml
+++ b/feature/bookmark/src/commonMain/composeResources/values/strings.xml
@@ -28,7 +28,10 @@
     <!-- Bookmark Detail -->
     <string name="bookmark_detail_content">책 내용</string>
     <string name="bookmark_detail_memo">개인 메모</string>
-    <string name="bookmark_detail_delete_preparing">준비 중입니다.</string>
+    <string name="bookmark_delete_title">책갈피 삭제</string>
+    <string name="bookmark_delete_description">이 책갈피를 삭제하시겠습니까?</string>
+    <string name="bookmark_delete_cancel">취소</string>
+    <string name="bookmark_delete_confirm">삭제</string>
 
     <!-- Content Descriptions -->
     <string name="cd_back">뒤로가기</string>

--- a/feature/bookmark/src/commonMain/composeResources/values/strings.xml
+++ b/feature/bookmark/src/commonMain/composeResources/values/strings.xml
@@ -3,6 +3,7 @@
     <string name="pages_format">/ %1$d 페이지</string>
     <string name="progress_format">%1$d% 진행중</string>
     <string name="mark_as_complete">완독으로 표시하기</string>
+    <string name="restart_reading">다시 읽기</string>
     <string name="tab_text">텍스트</string>
     <string name="tab_photo">사진</string>
     <string name="page_format">p.%1$d</string>

--- a/feature/bookmark/src/commonMain/composeResources/values/strings.xml
+++ b/feature/bookmark/src/commonMain/composeResources/values/strings.xml
@@ -3,7 +3,6 @@
     <string name="pages_format">/ %1$d 페이지</string>
     <string name="progress_format">%1$d% 진행중</string>
     <string name="mark_as_complete">완독으로 표시하기</string>
-    <string name="restart_reading">다시 읽기</string>
     <string name="tab_text">텍스트</string>
     <string name="tab_photo">사진</string>
     <string name="page_format">p.%1$d</string>

--- a/feature/bookmark/src/commonMain/composeResources/values/strings.xml
+++ b/feature/bookmark/src/commonMain/composeResources/values/strings.xml
@@ -25,9 +25,15 @@
     <string name="bookmark_memo_placeholder">생각을 기록하세요 (선택사항)</string>
     <string name="bookmark_save">책갈피 저장</string>
 
+    <!-- Bookmark Detail -->
+    <string name="bookmark_detail_content">책 내용</string>
+    <string name="bookmark_detail_memo">개인 메모</string>
+    <string name="bookmark_detail_delete_preparing">준비 중입니다.</string>
+
     <!-- Content Descriptions -->
     <string name="cd_back">뒤로가기</string>
     <string name="cd_add_bookmark">북마크 추가</string>
     <string name="cd_text_bookmark">텍스트 북마크</string>
     <string name="cd_photo_bookmark">사진 북마크</string>
+    <string name="cd_delete_bookmark">책갈피 삭제</string>
 </resources>

--- a/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/add/AddBookmarkScreen.kt
+++ b/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/add/AddBookmarkScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
@@ -42,6 +43,7 @@ fun AddBookmarkScreen(
     bookId: Long,
     bookmarkType: BookmarkType,
     onNavigateBack: () -> Unit,
+    onBookmarkSaved: () -> Unit,
 ) {
     val viewModel: AddBookmarkViewModel = koinViewModel()
     val state by viewModel.uiState.collectAsStateWithLifecycle()
@@ -72,8 +74,12 @@ fun AddBookmarkScreen(
     }
 
     LaunchedEffect(bookId, bookmarkType) {
-        viewModel.init(bookId, bookmarkType)
+        viewModel.onScreenEnter(bookId, bookmarkType)
         launchPicker(bookmarkType)
+    }
+
+    DisposableEffect(Unit) {
+        onDispose { viewModel.onScreenExit() }
     }
 
     viewModel.sideEffect.collectSideEffect {
@@ -82,7 +88,7 @@ fun AddBookmarkScreen(
                 snackbarHost.showSnackbar(it.message)
             }
             AddBookmarkSideEffect.NavigateBack -> onNavigateBack()
-            AddBookmarkSideEffect.BookmarkSaved -> onNavigateBack()
+            AddBookmarkSideEffect.BookmarkSaved -> onBookmarkSaved()
         }
     }
 

--- a/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/add/AddBookmarkScreen.kt
+++ b/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/add/AddBookmarkScreen.kt
@@ -28,6 +28,7 @@ import coil3.compose.AsyncImage
 import com.phase.bookpin.common.extensions.collectSideEffect
 import com.phase.bookpin.common.snackbar.LocalSnackbarHost
 import com.phase.bookpin.designsystem.BookPinTheme
+import com.phase.bookpin.designsystem.component.BPCloseButton
 import com.phase.bookpin.designsystem.component.BPLoadingScreen
 import com.phase.bookpin.designsystem.component.BPTextArea
 import com.phase.bookpin.designsystem.component.BPTopBar
@@ -93,7 +94,8 @@ fun AddBookmarkScreen(
         ) {
             BPTopBar(
                 title = stringResource(Res.string.bookmark_add_title),
-                onClose = viewModel::onCloseClick,
+                actions = { BPCloseButton(onClick = viewModel::onCloseClick) },
+                showBottomBorder = true,
             )
 
             Column(

--- a/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/add/AddBookmarkViewModel.kt
+++ b/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/add/AddBookmarkViewModel.kt
@@ -58,7 +58,7 @@ class AddBookmarkViewModel(
                     imageRepository.uploadImage(bytes, extension).getOrThrow()
                 }
             } else {
-                Result.success("")
+                Result.success(null)
             }
 
             imageUrlResult.onFailure { error ->
@@ -74,7 +74,7 @@ class AddBookmarkViewModel(
             val imageUrl = imageUrlResult.getOrThrow()
 
             bookRepository
-                .createBookmark(
+                .addBookmark(
                     bookId = bookId,
                     pageNumber = pageNumber,
                     extractedText = state.extractedText,

--- a/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/add/AddBookmarkViewModel.kt
+++ b/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/add/AddBookmarkViewModel.kt
@@ -17,9 +17,13 @@ class AddBookmarkViewModel(
 
     private var bookId: Long = 0L
 
-    fun init(bookId: Long, bookmarkType: BookmarkType) {
+    fun onScreenEnter(bookId: Long, bookmarkType: BookmarkType) {
         this.bookId = bookId
         reduce { copy(bookmarkType = bookmarkType) }
+    }
+
+    fun onScreenExit() {
+        reduce { AddBookmarkState() }
     }
 
     fun onExtractedTextChanged(text: String) {

--- a/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/add/BookmarkTypeSelectScreen.kt
+++ b/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/add/BookmarkTypeSelectScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.unit.dp
 import bookpin.bookmark.generated.resources.*
 import com.phase.bookpin.bookmark.component.BookmarkTypeOptionCard
 import com.phase.bookpin.designsystem.BookPinTheme
+import com.phase.bookpin.designsystem.component.BPCloseButton
 import com.phase.bookpin.designsystem.component.BPTopBar
 import com.phase.bookpin.model.bookmark.BookmarkType
 import org.jetbrains.compose.resources.painterResource
@@ -29,7 +30,8 @@ fun BookmarkTypeSelectScreen(
     ) {
         BPTopBar(
             title = stringResource(Res.string.bookmark_add_title),
-            onClose = onNavigateBack,
+            actions = { BPCloseButton(onClick = onNavigateBack) },
+            showBottomBorder = true,
         )
 
         Column(

--- a/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/detail/BookDetailScreen.kt
+++ b/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/detail/BookDetailScreen.kt
@@ -43,6 +43,7 @@ fun BookDetailScreen(
     bookId: Long,
     onNavigateBack: () -> Unit = {},
     onNavigateToAddBookmark: () -> Unit = {},
+    onNavigateToBookmarkDetail: (book: BookDetail, bookmark: Bookmark) -> Unit = { _, _ -> },
 ) {
     val viewModel: BookDetailViewModel = koinViewModel()
     val state by viewModel.uiState.collectAsStateWithLifecycle()
@@ -59,6 +60,9 @@ fun BookDetailScreen(
             }
             BookDetailSideEffect.NavigateBack -> onNavigateBack()
             BookDetailSideEffect.NavigateToAddBookmark -> onNavigateToAddBookmark()
+            is BookDetailSideEffect.NavigateToBookmarkDetail -> {
+                onNavigateToBookmarkDetail(state.book, it.bookmark)
+            }
         }
     }
 
@@ -122,7 +126,10 @@ fun BookDetailScreen(
 
                 if (state.selectedTab == BookmarkTab.TEXT) {
                     items(state.textBookmarks, key = { it.id }) { bookmark ->
-                        TextBookmarkItem(bookmark = bookmark)
+                        TextBookmarkItem(
+                            bookmark = bookmark,
+                            onClick = { viewModel.onBookmarkClick(bookmark) },
+                        )
                     }
                 } else {
                     items(state.photoBookmarks.chunked(2)) { rowItems ->
@@ -136,6 +143,7 @@ fun BookDetailScreen(
                             rowItems.forEach { bookmark ->
                                 PhotoBookmarkItem(
                                     bookmark = bookmark,
+                                    onClick = { viewModel.onBookmarkClick(bookmark) },
                                     modifier = Modifier.weight(1f),
                                 )
                             }
@@ -374,6 +382,7 @@ private fun TabItem(
 @Composable
 private fun TextBookmarkItem(
     bookmark: Bookmark,
+    onClick: () -> Unit,
 ) {
     Column(
         modifier = Modifier
@@ -386,7 +395,9 @@ private fun TextBookmarkItem(
             ).background(
                 color = BookPinTheme.colors.bgElevated,
                 shape = RoundedCornerShape(16.dp),
-            ).padding(16.dp),
+            ).clip(RoundedCornerShape(16.dp))
+            .clickable(onClick = onClick)
+            .padding(16.dp),
     ) {
         Text(
             text = stringResource(Res.string.page_format, bookmark.pageNumber),
@@ -419,6 +430,7 @@ private fun TextBookmarkItem(
 @Composable
 private fun PhotoBookmarkItem(
     bookmark: Bookmark,
+    onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -433,7 +445,8 @@ private fun PhotoBookmarkItem(
                 width = 0.5.dp,
                 color = BookPinTheme.colors.borderSubtle,
                 shape = RoundedCornerShape(16.dp),
-            ).clip(RoundedCornerShape(16.dp)),
+            ).clip(RoundedCornerShape(16.dp))
+            .clickable(onClick = onClick),
     ) {
         Box(
             modifier = Modifier

--- a/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/detail/BookDetailScreen.kt
+++ b/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/detail/BookDetailScreen.kt
@@ -301,17 +301,17 @@ private fun BookDetailStats(
                         color = BookPinTheme.colors.bgSurface,
                         shape = RoundedCornerShape(12.dp),
                     ).clip(RoundedCornerShape(12.dp))
-                    .clickable(onClick = onMarkAsCompleteClick),
+                    .clickable(enabled = !isCompleted, onClick = onMarkAsCompleteClick),
                 contentAlignment = Alignment.Center,
             ) {
                 Text(
-                    text = if (isCompleted) {
-                        stringResource(Res.string.restart_reading)
-                    } else {
-                        stringResource(Res.string.mark_as_complete)
-                    },
+                    text = stringResource(Res.string.mark_as_complete),
                     style = BookPinTheme.typography.titleSmall,
-                    color = BookPinTheme.colors.textSecondary,
+                    color = if (isCompleted) {
+                        BookPinTheme.colors.textSecondary.copy(alpha = 0.4f)
+                    } else {
+                        BookPinTheme.colors.textSecondary
+                    },
                 )
             }
         }

--- a/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/detail/BookDetailScreen.kt
+++ b/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/detail/BookDetailScreen.kt
@@ -70,7 +70,7 @@ fun BookDetailScreen(
 
     Scaffold(
         floatingActionButton = {
-            if (!state.isCompleted) {
+            if (!state.book.isCompleted) {
                 FloatingActionButton(
                     onClick = viewModel::onAddBookmarkClick,
                     containerColor = BookPinTheme.colors.buttonPrimary,
@@ -115,7 +115,7 @@ fun BookDetailScreen(
                         currentPage = state.book.currentPage,
                         totalPages = state.book.totalPage,
                         progressPercent = state.book.progress.toInt(),
-                        isCompleted = state.isCompleted,
+                        isCompleted = state.book.isCompleted,
                         onMarkAsCompleteClick = viewModel::onMarkAsCompleteClick,
                     )
                 }

--- a/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/detail/BookDetailScreen.kt
+++ b/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/detail/BookDetailScreen.kt
@@ -66,18 +66,20 @@ fun BookDetailScreen(
 
     Scaffold(
         floatingActionButton = {
-            FloatingActionButton(
-                onClick = viewModel::onAddBookmarkClick,
-                containerColor = BookPinTheme.colors.buttonPrimary,
-                contentColor = BookPinTheme.colors.iconOnAccent,
-                shape = CircleShape,
-                modifier = Modifier.size(56.dp),
-            ) {
-                Icon(
-                    painter = painterResource(Res.drawable.ic_add),
-                    contentDescription = stringResource(Res.string.cd_add_bookmark),
-                    modifier = Modifier.size(24.dp),
-                )
+            if (!state.isCompleted) {
+                FloatingActionButton(
+                    onClick = viewModel::onAddBookmarkClick,
+                    containerColor = BookPinTheme.colors.buttonPrimary,
+                    contentColor = BookPinTheme.colors.iconOnAccent,
+                    shape = CircleShape,
+                    modifier = Modifier.size(56.dp),
+                ) {
+                    Icon(
+                        painter = painterResource(Res.drawable.ic_add),
+                        contentDescription = stringResource(Res.string.cd_add_bookmark),
+                        modifier = Modifier.size(24.dp),
+                    )
+                }
             }
         },
     ) { paddingValues ->
@@ -109,6 +111,7 @@ fun BookDetailScreen(
                         currentPage = state.book.currentPage,
                         totalPages = state.book.totalPage,
                         progressPercent = state.book.progress.toInt(),
+                        isCompleted = state.isCompleted,
                         onMarkAsCompleteClick = viewModel::onMarkAsCompleteClick,
                     )
                 }
@@ -210,6 +213,7 @@ private fun BookDetailStats(
     currentPage: Int,
     totalPages: Int,
     progressPercent: Int,
+    isCompleted: Boolean,
     onMarkAsCompleteClick: () -> Unit,
 ) {
     Box(
@@ -293,7 +297,11 @@ private fun BookDetailStats(
                 contentAlignment = Alignment.Center,
             ) {
                 Text(
-                    text = stringResource(Res.string.mark_as_complete),
+                    text = if (isCompleted) {
+                        stringResource(Res.string.restart_reading)
+                    } else {
+                        stringResource(Res.string.mark_as_complete)
+                    },
                     style = BookPinTheme.typography.titleSmall,
                     color = BookPinTheme.colors.textSecondary,
                 )

--- a/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/detail/BookDetailSideEffect.kt
+++ b/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/detail/BookDetailSideEffect.kt
@@ -1,9 +1,14 @@
 package com.phase.bookpin.bookmark.detail
 
+import com.phase.bookpin.model.book.Bookmark
+
 sealed interface BookDetailSideEffect {
     data class ShowSnackbar(
         val message: String,
     ) : BookDetailSideEffect
     data object NavigateBack : BookDetailSideEffect
     data object NavigateToAddBookmark : BookDetailSideEffect
+    data class NavigateToBookmarkDetail(
+        val bookmark: Bookmark,
+    ) : BookDetailSideEffect
 }

--- a/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/detail/BookDetailState.kt
+++ b/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/detail/BookDetailState.kt
@@ -9,7 +9,6 @@ data class BookDetailState(
     val photoBookmarks: List<Bookmark> = emptyList(),
     val selectedTab: BookmarkTab = BookmarkTab.TEXT,
     val isLoading: Boolean = false,
-    val isCompleted: Boolean = false,
 )
 
 enum class BookmarkTab {

--- a/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/detail/BookDetailState.kt
+++ b/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/detail/BookDetailState.kt
@@ -9,6 +9,7 @@ data class BookDetailState(
     val photoBookmarks: List<Bookmark> = emptyList(),
     val selectedTab: BookmarkTab = BookmarkTab.TEXT,
     val isLoading: Boolean = false,
+    val isCompleted: Boolean = false,
 )
 
 enum class BookmarkTab {

--- a/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/detail/BookDetailViewModel.kt
+++ b/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/detail/BookDetailViewModel.kt
@@ -24,7 +24,7 @@ class BookDetailViewModel(
             bookRepository
                 .getBookDetail(bookId)
                 .onSuccess { book ->
-                    reduce { copy(book = book, isLoading = false, isCompleted = book.isCompleted) }
+                    reduce { copy(book = book, isLoading = false) }
                 }.onFailure { error ->
                     reduce { copy(isLoading = false) }
                     postSideEffect(BookDetailSideEffect.ShowSnackbar(error.message ?: "오류가 발생했습니다."))
@@ -72,7 +72,7 @@ class BookDetailViewModel(
             bookRepository
                 .completeBook(bookId)
                 .onSuccess {
-                    reduce { copy(isLoading = false, isCompleted = true) }
+                    reduce { copy(isLoading = false) }
                     postSideEffect(BookDetailSideEffect.ShowSnackbar("완독으로 표시되었습니다"))
                     postSideEffect(BookDetailSideEffect.NavigateToHome)
                 }.onFailure { error ->

--- a/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/detail/BookDetailViewModel.kt
+++ b/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/detail/BookDetailViewModel.kt
@@ -3,6 +3,7 @@ package com.phase.bookpin.bookmark.detail
 import androidx.lifecycle.viewModelScope
 import com.phase.bookpin.common.BaseViewModel
 import com.phase.bookpin.domain.book.BookRepository
+import com.phase.bookpin.model.book.Bookmark
 import kotlinx.coroutines.launch
 
 class BookDetailViewModel(
@@ -70,5 +71,9 @@ class BookDetailViewModel(
 
     fun onAddBookmarkClick() {
         postSideEffect(BookDetailSideEffect.NavigateToAddBookmark)
+    }
+
+    fun onBookmarkClick(bookmark: Bookmark) {
+        postSideEffect(BookDetailSideEffect.NavigateToBookmarkDetail(bookmark))
     }
 }

--- a/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/detail/BookDetailViewModel.kt
+++ b/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/detail/BookDetailViewModel.kt
@@ -23,7 +23,7 @@ class BookDetailViewModel(
             bookRepository
                 .getBookDetail(bookId)
                 .onSuccess { book ->
-                    reduce { copy(book = book, isLoading = false) }
+                    reduce { copy(book = book, isLoading = false, isCompleted = book.progress >= 100.0) }
                 }.onFailure { error ->
                     reduce { copy(isLoading = false) }
                     postSideEffect(BookDetailSideEffect.ShowSnackbar(error.message ?: "오류가 발생했습니다."))
@@ -71,7 +71,7 @@ class BookDetailViewModel(
             bookRepository
                 .completeBook(bookId)
                 .onSuccess {
-                    reduce { copy(isLoading = false, book = book.copy(isCompleted = true)) }
+                    reduce { copy(isLoading = false, isCompleted = true) }
                     postSideEffect(BookDetailSideEffect.ShowSnackbar("완독으로 표시되었습니다"))
                     postSideEffect(BookDetailSideEffect.NavigateToHome)
                 }.onFailure { error ->

--- a/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/detail/BookmarkDetailScreen.kt
+++ b/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/detail/BookmarkDetailScreen.kt
@@ -163,7 +163,7 @@ private fun BookInfoSection(
     ) {
         AsyncImage(
             model = bookImageUrl,
-            contentDescription = null,
+            contentDescription = bookTitle,
             modifier = Modifier
                 .width(48.dp)
                 .height(72.dp)
@@ -194,7 +194,7 @@ private fun BookInfoSection(
             Spacer(modifier = Modifier.height(2.dp))
 
             Text(
-                text = "p.$pageNumber · $createdAt",
+                text = "${stringResource(Res.string.page_format, pageNumber)} · $createdAt",
                 style = BookPinTheme.typography.bodySmall,
                 color = BookPinTheme.colors.textSecondary,
             )
@@ -215,7 +215,7 @@ private fun BookmarkPhotoSection(
 ) {
     AsyncImage(
         model = imageUrl,
-        contentDescription = null,
+        contentDescription = stringResource(Res.string.cd_photo_bookmark),
         modifier = Modifier
             .fillMaxWidth()
             .clip(RoundedCornerShape(16.dp))

--- a/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/detail/BookmarkDetailScreen.kt
+++ b/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/detail/BookmarkDetailScreen.kt
@@ -11,6 +11,8 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -23,14 +25,20 @@ import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.unit.dp
 import bookpin.bookmark.generated.resources.*
 import coil3.compose.AsyncImage
+import com.phase.bookpin.common.extensions.collectSideEffect
 import com.phase.bookpin.common.snackbar.LocalSnackbarHost
 import com.phase.bookpin.designsystem.BookPinTheme
+import com.phase.bookpin.designsystem.component.BPConfirmDialog
+import com.phase.bookpin.designsystem.component.BPLoadingScreen
 import com.phase.bookpin.designsystem.component.BPTopBar
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
+import org.koin.compose.viewmodel.koinViewModel
 
 @Composable
 fun BookmarkDetailScreen(
+    bookId: Long,
+    bookmarkId: Long,
     bookTitle: String,
     bookAuthor: String,
     bookImageUrl: String,
@@ -40,9 +48,26 @@ fun BookmarkDetailScreen(
     imageUrl: String,
     createdAt: String,
     onNavigateBack: () -> Unit,
+    viewModel: BookmarkDetailViewModel = koinViewModel(),
 ) {
+    val state by viewModel.uiState.collectAsState()
     val snackbarHost = LocalSnackbarHost.current
-    val deletePreparingMessage = stringResource(Res.string.bookmark_detail_delete_preparing)
+
+    viewModel.sideEffect.collectSideEffect { sideEffect ->
+        when (sideEffect) {
+            is BookmarkDetailSideEffect.ShowSnackbar -> {
+                snackbarHost.showSnackbar(sideEffect.message)
+            }
+            is BookmarkDetailSideEffect.NavigateBack -> {
+                onNavigateBack()
+            }
+        }
+    }
+
+    if (state.isLoading) {
+        BPLoadingScreen()
+        return
+    }
 
     Column(
         modifier = Modifier
@@ -65,7 +90,7 @@ fun BookmarkDetailScreen(
             },
             actions = {
                 IconButton(
-                    onClick = { snackbarHost.showSnackbar(deletePreparingMessage) },
+                    onClick = { viewModel.onDeleteClick() },
                     modifier = Modifier.size(36.dp),
                 ) {
                     Icon(
@@ -77,6 +102,18 @@ fun BookmarkDetailScreen(
                 }
             },
         )
+
+        if (state.showDeleteDialog) {
+            BPConfirmDialog(
+                title = stringResource(Res.string.bookmark_delete_title),
+                description = stringResource(Res.string.bookmark_delete_description),
+                cancelText = stringResource(Res.string.bookmark_delete_cancel),
+                confirmText = stringResource(Res.string.bookmark_delete_confirm),
+                confirmButtonColor = BookPinTheme.colors.error,
+                onDismiss = viewModel::onDeleteDismiss,
+                onConfirm = { viewModel.onDeleteConfirm(bookId, bookmarkId) },
+            )
+        }
 
         Column(
             modifier = Modifier

--- a/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/detail/BookmarkDetailScreen.kt
+++ b/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/detail/BookmarkDetailScreen.kt
@@ -1,0 +1,293 @@
+package com.phase.bookpin.bookmark.detail
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.unit.dp
+import bookpin.bookmark.generated.resources.*
+import coil3.compose.AsyncImage
+import com.phase.bookpin.common.snackbar.LocalSnackbarHost
+import com.phase.bookpin.designsystem.BookPinTheme
+import com.phase.bookpin.designsystem.component.BPTopBar
+import org.jetbrains.compose.resources.painterResource
+import org.jetbrains.compose.resources.stringResource
+
+@Composable
+fun BookmarkDetailScreen(
+    bookTitle: String,
+    bookAuthor: String,
+    bookImageUrl: String,
+    pageNumber: Int,
+    extractedText: String,
+    note: String,
+    imageUrl: String,
+    createdAt: String,
+    onNavigateBack: () -> Unit,
+) {
+    val snackbarHost = LocalSnackbarHost.current
+    val deletePreparingMessage = stringResource(Res.string.bookmark_detail_delete_preparing)
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(BookPinTheme.colors.bgCanvas),
+    ) {
+        BPTopBar(
+            navigationIcon = {
+                IconButton(
+                    onClick = onNavigateBack,
+                    modifier = Modifier.size(36.dp),
+                ) {
+                    Icon(
+                        painter = painterResource(Res.drawable.ic_arrow_back),
+                        contentDescription = stringResource(Res.string.cd_back),
+                        modifier = Modifier.size(20.dp),
+                        tint = BookPinTheme.colors.iconDefault,
+                    )
+                }
+            },
+            actions = {
+                IconButton(
+                    onClick = { snackbarHost.showSnackbar(deletePreparingMessage) },
+                    modifier = Modifier.size(36.dp),
+                ) {
+                    Icon(
+                        painter = painterResource(Res.drawable.ic_delete),
+                        contentDescription = stringResource(Res.string.cd_delete_bookmark),
+                        modifier = Modifier.size(20.dp),
+                        tint = BookPinTheme.colors.iconDefault,
+                    )
+                }
+            },
+        )
+
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 24.dp),
+        ) {
+            Spacer(modifier = Modifier.height(16.dp))
+
+            BookInfoSection(
+                bookTitle = bookTitle,
+                bookAuthor = bookAuthor,
+                bookImageUrl = bookImageUrl,
+                pageNumber = pageNumber,
+                createdAt = createdAt,
+            )
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            if (imageUrl.isNotEmpty()) {
+                BookmarkPhotoSection(imageUrl = imageUrl)
+                Spacer(modifier = Modifier.height(24.dp))
+            }
+
+            BookContentSection(extractedText = extractedText)
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            PersonalMemoSection(note = note)
+
+            Spacer(modifier = Modifier.height(32.dp))
+        }
+    }
+}
+
+@Composable
+private fun BookInfoSection(
+    bookTitle: String,
+    bookAuthor: String,
+    bookImageUrl: String,
+    pageNumber: Int,
+    createdAt: String,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        AsyncImage(
+            model = bookImageUrl,
+            contentDescription = null,
+            modifier = Modifier
+                .width(48.dp)
+                .height(72.dp)
+                .clip(RoundedCornerShape(4.dp))
+                .background(BookPinTheme.colors.bgSurface),
+            contentScale = ContentScale.Crop,
+        )
+
+        Spacer(modifier = Modifier.width(12.dp))
+
+        Column(
+            modifier = Modifier.weight(1f),
+        ) {
+            Text(
+                text = bookTitle,
+                style = BookPinTheme.typography.titleMedium,
+                color = BookPinTheme.colors.textPrimary,
+            )
+
+            Spacer(modifier = Modifier.height(2.dp))
+
+            Text(
+                text = bookAuthor,
+                style = BookPinTheme.typography.bodyMedium,
+                color = BookPinTheme.colors.textSecondary,
+            )
+
+            Spacer(modifier = Modifier.height(2.dp))
+
+            Text(
+                text = "p.$pageNumber · $createdAt",
+                style = BookPinTheme.typography.bodySmall,
+                color = BookPinTheme.colors.textSecondary,
+            )
+        }
+    }
+
+    Spacer(modifier = Modifier.height(16.dp))
+
+    HorizontalDivider(
+        color = BookPinTheme.colors.borderSubtle.copy(alpha = 0.5f),
+        thickness = 1.dp,
+    )
+}
+
+@Composable
+private fun BookmarkPhotoSection(
+    imageUrl: String,
+) {
+    AsyncImage(
+        model = imageUrl,
+        contentDescription = null,
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(16.dp))
+            .border(
+                width = 1.dp,
+                color = BookPinTheme.colors.borderSubtle,
+                shape = RoundedCornerShape(16.dp),
+            ),
+        contentScale = ContentScale.FillWidth,
+    )
+}
+
+@Composable
+private fun BookContentSection(
+    extractedText: String,
+) {
+    Text(
+        text = stringResource(Res.string.bookmark_detail_content),
+        style = BookPinTheme.typography.titleMedium,
+        color = BookPinTheme.colors.textTertiary,
+    )
+
+    Spacer(modifier = Modifier.height(8.dp))
+
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .shadow(
+                elevation = 2.dp,
+                shape = RoundedCornerShape(16.dp),
+            ).background(
+                color = BookPinTheme.colors.bgElevated,
+                shape = RoundedCornerShape(16.dp),
+            ).padding(16.dp),
+    ) {
+        Text(
+            text = extractedText,
+            style = BookPinTheme.typography.bodyMedium,
+            color = BookPinTheme.colors.textPrimary,
+        )
+    }
+}
+
+@Composable
+private fun PersonalMemoSection(
+    note: String,
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .drawDashedTopBorder(
+                color = BookPinTheme.colors.borderDefault,
+            ).padding(top = 16.dp),
+    ) {
+        Column {
+            Text(
+                text = stringResource(Res.string.bookmark_detail_memo),
+                style = BookPinTheme.typography.titleMedium,
+                color = BookPinTheme.colors.textTertiary,
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .shadow(
+                        elevation = 2.dp,
+                        shape = RoundedCornerShape(16.dp),
+                    ).background(
+                        color = BookPinTheme.colors.bgElevated,
+                        shape = RoundedCornerShape(16.dp),
+                    ).padding(16.dp),
+            ) {
+                Text(
+                    text = note.ifEmpty { "-" },
+                    style = BookPinTheme.typography.bodyMedium.copy(
+                        fontStyle = if (note.isEmpty()) FontStyle.Italic else FontStyle.Normal,
+                    ),
+                    color = if (note.isEmpty()) {
+                        BookPinTheme.colors.textPlaceholder
+                    } else {
+                        BookPinTheme.colors.textPrimary
+                    },
+                )
+            }
+        }
+    }
+}
+
+private fun Modifier.drawDashedTopBorder(
+    color: Color,
+): Modifier = this.then(
+    Modifier.drawBehind {
+        val dashWidth = 6.dp.toPx()
+        val dashGap = 4.dp.toPx()
+        val strokeWidth = 1.dp.toPx()
+        var x = 0f
+        while (x < size.width) {
+            drawLine(
+                color = color,
+                start = Offset(x, 0f),
+                end = Offset(
+                    (x + dashWidth).coerceAtMost(size.width),
+                    0f,
+                ),
+                strokeWidth = strokeWidth,
+            )
+            x += dashWidth + dashGap
+        }
+    },
+)

--- a/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/detail/BookmarkDetailSideEffect.kt
+++ b/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/detail/BookmarkDetailSideEffect.kt
@@ -1,0 +1,8 @@
+package com.phase.bookpin.bookmark.detail
+
+sealed interface BookmarkDetailSideEffect {
+    data class ShowSnackbar(
+        val message: String,
+    ) : BookmarkDetailSideEffect
+    data object NavigateBack : BookmarkDetailSideEffect
+}

--- a/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/detail/BookmarkDetailState.kt
+++ b/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/detail/BookmarkDetailState.kt
@@ -1,0 +1,6 @@
+package com.phase.bookpin.bookmark.detail
+
+data class BookmarkDetailState(
+    val isLoading: Boolean = false,
+    val showDeleteDialog: Boolean = false,
+)

--- a/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/detail/BookmarkDetailViewModel.kt
+++ b/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/detail/BookmarkDetailViewModel.kt
@@ -1,0 +1,41 @@
+package com.phase.bookpin.bookmark.detail
+
+import androidx.lifecycle.viewModelScope
+import com.phase.bookpin.common.BaseViewModel
+import com.phase.bookpin.domain.book.BookRepository
+import kotlinx.coroutines.launch
+
+class BookmarkDetailViewModel(
+    private val bookRepository: BookRepository,
+) : BaseViewModel<BookmarkDetailState, BookmarkDetailSideEffect>() {
+    override fun createInitialState(): BookmarkDetailState = BookmarkDetailState()
+
+    fun onDeleteClick() {
+        reduce { copy(showDeleteDialog = true) }
+    }
+
+    fun onDeleteDismiss() {
+        reduce { copy(showDeleteDialog = false) }
+    }
+
+    fun onDeleteConfirm(bookId: Long, bookmarkId: Long) {
+        reduce { copy(showDeleteDialog = false) }
+        if (uiState.value.isLoading) return
+        viewModelScope.launch {
+            reduce { copy(isLoading = true) }
+            bookRepository
+                .deleteBookmark(bookId, bookmarkId)
+                .onSuccess {
+                    reduce { copy(isLoading = false) }
+                    postSideEffect(BookmarkDetailSideEffect.NavigateBack)
+                }.onFailure { error ->
+                    reduce { copy(isLoading = false) }
+                    postSideEffect(
+                        BookmarkDetailSideEffect.ShowSnackbar(
+                            error.message ?: "오류가 발생했습니다.",
+                        ),
+                    )
+                }
+        }
+    }
+}

--- a/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/di/BookDetailModule.kt
+++ b/feature/bookmark/src/commonMain/kotlin/com/phase/bookpin/bookmark/di/BookDetailModule.kt
@@ -2,6 +2,7 @@ package com.phase.bookpin.bookmark.di
 
 import com.phase.bookpin.bookmark.add.AddBookmarkViewModel
 import com.phase.bookpin.bookmark.detail.BookDetailViewModel
+import com.phase.bookpin.bookmark.detail.BookmarkDetailViewModel
 import org.koin.core.module.dsl.viewModelOf
 import org.koin.dsl.module
 
@@ -9,4 +10,5 @@ val bookDetailModule = module {
     includes(bookmarkPlatformModule)
     viewModelOf(::BookDetailViewModel)
     viewModelOf(::AddBookmarkViewModel)
+    viewModelOf(::BookmarkDetailViewModel)
 }

--- a/feature/home/src/commonMain/composeResources/values/strings.xml
+++ b/feature/home/src/commonMain/composeResources/values/strings.xml
@@ -12,7 +12,7 @@
     <string name="unknown_error_message">알 수 없는 예외가 발생하였습니다</string>
 
     <string name="completed_badge">완독</string>
-    <string name="all_pages_read">%dp 모두 읽음</string>
+    <string name="all_pages_read">%1$dp 모두 읽음</string>
 
     <!-- Content Descriptions -->
     <string name="cd_bookpin_icon">BookPin 아이콘</string>

--- a/feature/home/src/commonMain/composeResources/values/strings.xml
+++ b/feature/home/src/commonMain/composeResources/values/strings.xml
@@ -11,6 +11,9 @@
     <string name="empty_bookshelf">추가된 책이 없습니다. \n 책 추가 버튼을 통해 책을 추가해보세요!</string>
     <string name="unknown_error_message">알 수 없는 예외가 발생하였습니다</string>
 
+    <string name="completed_badge">완독</string>
+    <string name="all_pages_read">%dp 모두 읽음</string>
+
     <!-- Content Descriptions -->
     <string name="cd_bookpin_icon">BookPin 아이콘</string>
     <string name="cd_settings">설정</string>

--- a/feature/home/src/commonMain/kotlin/com/phase/bookpin/home/HomeScreen.kt
+++ b/feature/home/src/commonMain/kotlin/com/phase/bookpin/home/HomeScreen.kt
@@ -55,7 +55,7 @@ fun HomeScreen(
             }
             HomeSideEffect.NavigateToSettings -> onNavigateToSettings()
             is HomeSideEffect.NavigateToBookDetail -> onNavigateToBookDetail(it.bookId)
-            is HomeSideEffect.NavigateToAddBookmark -> {}
+            is HomeSideEffect.NavigateToAddBookmark -> onNavigateToBookDetail(it.bookId)
             HomeSideEffect.NavigateToAddBook -> onNavigateToSearch()
         }
     }

--- a/feature/home/src/commonMain/kotlin/com/phase/bookpin/home/component/BookItemCard.kt
+++ b/feature/home/src/commonMain/kotlin/com/phase/bookpin/home/component/BookItemCard.kt
@@ -24,8 +24,10 @@ import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import bookpin.home.generated.resources.Res
+import bookpin.home.generated.resources.all_pages_read
 import bookpin.home.generated.resources.bookmark
 import bookpin.home.generated.resources.cd_bookmark
+import bookpin.home.generated.resources.completed_badge
 import coil3.compose.AsyncImage
 import com.phase.bookpin.designsystem.BookPinTheme
 import com.phase.bookpin.model.book.BookItem
@@ -60,6 +62,10 @@ internal fun BookItemCard(
                 model = bookItem.imageUrl,
                 contentDescription = null,
             )
+
+            if (bookItem.isCompleted) {
+                CompletedBadge(modifier = Modifier.align(Alignment.TopEnd))
+            }
         }
 
         Spacer(modifier = Modifier.height(12.dp))
@@ -84,18 +90,26 @@ internal fun BookItemCard(
             verticalAlignment = Alignment.Bottom,
             horizontalArrangement = Arrangement.SpaceBetween,
         ) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
+            if (bookItem.isCompleted) {
                 Text(
-                    text = "${bookItem.currentPage} / ${bookItem.totalPage} ",
-                    style = BookPinTheme.typography.labelSmall,
-                    color = BookPinTheme.colors.textSecondary,
-                )
-
-                Text(
-                    text = "(${bookItem.progress}%)",
+                    text = stringResource(Res.string.all_pages_read, bookItem.totalPage),
                     style = BookPinTheme.typography.labelMedium,
-                    color = BookPinTheme.colors.textAccent,
+                    color = BookPinTheme.colors.textTertiary,
                 )
+            } else {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Text(
+                        text = "${bookItem.currentPage} / ${bookItem.totalPage} ",
+                        style = BookPinTheme.typography.labelSmall,
+                        color = BookPinTheme.colors.textSecondary,
+                    )
+
+                    Text(
+                        text = "(${bookItem.progress}%)",
+                        style = BookPinTheme.typography.labelMedium,
+                        color = BookPinTheme.colors.textAccent,
+                    )
+                }
             }
 
             Row(
@@ -140,4 +154,17 @@ internal fun BookItemCard(
             )
         }
     }
+}
+
+@Composable
+private fun CompletedBadge(modifier: Modifier = Modifier) {
+    Text(
+        text = stringResource(Res.string.completed_badge),
+        style = BookPinTheme.typography.labelSmall,
+        color = BookPinTheme.colors.textOnAccent,
+        modifier = modifier
+            .shadow(elevation = 2.dp, shape = CircleShape)
+            .background(color = BookPinTheme.colors.textPrimary, shape = CircleShape)
+            .padding(horizontal = 8.dp, vertical = 2.dp),
+    )
 }

--- a/feature/home/src/commonMain/kotlin/com/phase/bookpin/home/component/BookItemCard.kt
+++ b/feature/home/src/commonMain/kotlin/com/phase/bookpin/home/component/BookItemCard.kt
@@ -54,14 +54,25 @@ internal fun BookItemCard(
                 .height(128.dp),
             contentAlignment = Alignment.Center,
         ) {
-            AsyncImage(
-                modifier = Modifier
-                    .width(80.dp)
-                    .height(112.dp)
-                    .shadow(elevation = 4.dp),
-                model = bookItem.imageUrl,
-                contentDescription = null,
-            )
+            if (bookItem.imageUrl.isNotBlank()) {
+                AsyncImage(
+                    modifier = Modifier
+                        .width(80.dp)
+                        .height(112.dp)
+                        .shadow(elevation = 4.dp)
+                        .background(color = BookPinTheme.colors.buttonPrimary),
+                    model = bookItem.imageUrl,
+                    contentDescription = null,
+                )
+            } else {
+                Box(
+                    modifier = Modifier
+                        .width(80.dp)
+                        .height(112.dp)
+                        .shadow(elevation = 4.dp)
+                        .background(color = BookPinTheme.colors.buttonPrimary),
+                )
+            }
 
             if (bookItem.isCompleted) {
                 CompletedBadge(modifier = Modifier.align(Alignment.TopEnd))

--- a/feature/home/src/commonMain/kotlin/com/phase/bookpin/home/component/CurrentReadingCard.kt
+++ b/feature/home/src/commonMain/kotlin/com/phase/bookpin/home/component/CurrentReadingCard.kt
@@ -52,17 +52,21 @@ internal fun CurrentlyReadingCard(
         ) {
             Box(
                 modifier = Modifier
+                    .width(100.dp)
                     .height(144.dp)
-                    .shadow(elevation = 4.dp),
+                    .shadow(elevation = 4.dp)
+                    .background(color = BookPinTheme.colors.buttonPrimary),
                 contentAlignment = Alignment.Center,
             ) {
-                AsyncImage(
-                    modifier = Modifier
-                        .width(100.dp)
-                        .height(144.dp),
-                    model = bookItem.imageUrl,
-                    contentDescription = null,
-                )
+                if (bookItem.imageUrl.isNotBlank()) {
+                    AsyncImage(
+                        modifier = Modifier
+                            .width(100.dp)
+                            .height(144.dp),
+                        model = bookItem.imageUrl,
+                        contentDescription = null,
+                    )
+                }
             }
 
             Spacer(modifier = Modifier.width(20.dp))

--- a/feature/home/src/commonMain/kotlin/com/phase/bookpin/home/component/CurrentReadingCard.kt
+++ b/feature/home/src/commonMain/kotlin/com/phase/bookpin/home/component/CurrentReadingCard.kt
@@ -11,28 +11,22 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import bookpin.home.generated.resources.Res
-import bookpin.home.generated.resources.bookmark
-import bookpin.home.generated.resources.cd_bookmark
 import bookpin.home.generated.resources.leave_bookmark
 import coil3.compose.AsyncImage
 import com.phase.bookpin.designsystem.BookPinTheme
 import com.phase.bookpin.model.book.BookItem
-import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 
 @Composable
@@ -83,44 +77,11 @@ internal fun CurrentlyReadingCard(
 
                 Spacer(modifier = Modifier.height(4.dp))
 
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(6.dp),
-                ) {
-                    Text(
-                        text = bookItem.author,
-                        style = BookPinTheme.typography.titleSmall,
-                        color = BookPinTheme.colors.textSecondary,
-                    )
-
-                    Box(
-                        modifier = Modifier
-                            .size(4.dp)
-                            .background(
-                                color = BookPinTheme.colors.borderDefault,
-                                shape = CircleShape,
-                            ),
-                    )
-
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(4.dp),
-                        modifier = Modifier.padding(start = 4.dp),
-                    ) {
-                        Icon(
-                            painter = painterResource(Res.drawable.bookmark),
-                            contentDescription = stringResource(Res.string.cd_bookmark),
-                            modifier = Modifier.size(14.dp),
-                            tint = Color.Unspecified,
-                        )
-
-                        Text(
-                            text = "${bookItem.bookmarkCount}",
-                            style = BookPinTheme.typography.labelMedium,
-                            color = BookPinTheme.colors.textPrimary.copy(alpha = 0.8f),
-                        )
-                    }
-                }
+                Text(
+                    text = bookItem.author,
+                    style = BookPinTheme.typography.titleSmall,
+                    color = BookPinTheme.colors.textSecondary,
+                )
 
                 Spacer(modifier = Modifier.height(16.dp))
 

--- a/feature/search/src/commonMain/kotlin/com/phase/bookpin/search/SearchScreen.kt
+++ b/feature/search/src/commonMain/kotlin/com/phase/bookpin/search/SearchScreen.kt
@@ -250,7 +250,7 @@ private fun SearchResultItem(
         ) {
             Text(
                 text = book.title,
-                style = BookPinTheme.typography.headlineMedium,
+                style = BookPinTheme.typography.titleMedium,
                 color = BookPinTheme.colors.textPrimary,
                 maxLines = 2,
                 overflow = TextOverflow.Ellipsis,
@@ -260,7 +260,7 @@ private fun SearchResultItem(
 
             Text(
                 text = book.author,
-                style = BookPinTheme.typography.titleMedium,
+                style = BookPinTheme.typography.bodyMedium,
                 color = BookPinTheme.colors.textSecondary,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,

--- a/feature/search/src/commonMain/kotlin/com/phase/bookpin/search/preview/BookPreviewScreen.kt
+++ b/feature/search/src/commonMain/kotlin/com/phase/bookpin/search/preview/BookPreviewScreen.kt
@@ -115,7 +115,7 @@ fun BookPreviewScreen(
 
             FormField(
                 label = stringResource(Res.string.book_preview_label_total_page),
-                value = state.totalPage.toString(),
+                value = state.totalPage,
                 onValueChange = viewModel::onTotalPageChange,
                 placeholder = stringResource(Res.string.book_preview_placeholder_total_page),
                 keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),

--- a/feature/search/src/commonMain/kotlin/com/phase/bookpin/search/preview/BookPreviewScreen.kt
+++ b/feature/search/src/commonMain/kotlin/com/phase/bookpin/search/preview/BookPreviewScreen.kt
@@ -3,7 +3,6 @@ package com.phase.bookpin.search.preview
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
@@ -28,7 +27,9 @@ import com.phase.bookpin.common.extensions.collectSideEffect
 import com.phase.bookpin.common.extensions.noRippleClickable
 import com.phase.bookpin.common.snackbar.LocalSnackbarHost
 import com.phase.bookpin.designsystem.BookPinTheme
+import com.phase.bookpin.designsystem.component.BPCloseButton
 import com.phase.bookpin.designsystem.component.BPTextField
+import com.phase.bookpin.designsystem.component.BPTopBar
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.viewmodel.koinViewModel
@@ -69,9 +70,22 @@ fun BookPreviewScreen(
 
     Scaffold(
         topBar = {
-            BookPreviewTopBar(
-                onBackClick = viewModel::onBackClick,
-                onCloseClick = viewModel::onCloseClick,
+            BPTopBar(
+                title = stringResource(Res.string.book_preview_title),
+                navigationIcon = {
+                    IconButton(
+                        onClick = viewModel::onBackClick,
+                        modifier = Modifier.size(36.dp),
+                    ) {
+                        Icon(
+                            painter = painterResource(Res.drawable.ic_arrow_back),
+                            contentDescription = stringResource(Res.string.cd_back),
+                            modifier = Modifier.size(20.dp),
+                            tint = BookPinTheme.colors.iconDefault,
+                        )
+                    }
+                },
+                actions = { BPCloseButton(onClick = viewModel::onCloseClick) },
             )
         },
         bottomBar = {
@@ -122,60 +136,6 @@ fun BookPreviewScreen(
             )
 
             Spacer(modifier = Modifier.height(24.dp))
-        }
-    }
-}
-
-@Composable
-private fun BookPreviewTopBar(
-    onBackClick: () -> Unit,
-    onCloseClick: () -> Unit,
-) {
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 16.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.SpaceBetween,
-    ) {
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(12.dp),
-        ) {
-            IconButton(
-                onClick = onBackClick,
-                modifier = Modifier.size(40.dp),
-            ) {
-                Icon(
-                    painter = painterResource(Res.drawable.ic_arrow_back),
-                    contentDescription = stringResource(Res.string.cd_back),
-                    modifier = Modifier.size(24.dp),
-                    tint = BookPinTheme.colors.iconDefault,
-                )
-            }
-
-            Text(
-                text = stringResource(Res.string.book_preview_title),
-                style = BookPinTheme.typography.headlineMedium,
-                color = BookPinTheme.colors.textPrimary,
-            )
-        }
-
-        IconButton(
-            onClick = onCloseClick,
-            modifier = Modifier
-                .size(40.dp)
-                .background(
-                    color = BookPinTheme.colors.bgSurface,
-                    shape = CircleShape,
-                ),
-        ) {
-            Icon(
-                painter = painterResource(Res.drawable.ic_close),
-                contentDescription = stringResource(Res.string.cd_close),
-                modifier = Modifier.size(24.dp),
-                tint = BookPinTheme.colors.iconDefault,
-            )
         }
     }
 }

--- a/feature/search/src/commonMain/kotlin/com/phase/bookpin/search/preview/BookPreviewState.kt
+++ b/feature/search/src/commonMain/kotlin/com/phase/bookpin/search/preview/BookPreviewState.kt
@@ -3,11 +3,14 @@ package com.phase.bookpin.search.preview
 data class BookPreviewState(
     val title: String = "",
     val author: String = "",
-    val totalPage: Int = -1,
+    val totalPage: String = "",
     val imageUrl: String = "",
     val isbn: String = "",
     val isLoading: Boolean = false,
 ) {
     val isSubmitEnabled: Boolean
-        get() = title.isNotBlank() && author.isNotBlank() && totalPage > 0 && !isLoading
+        get() = title.isNotBlank() &&
+            author.isNotBlank() &&
+            totalPage.toIntOrNull()?.let { it > 0 } == true &&
+            !isLoading
 }

--- a/feature/search/src/commonMain/kotlin/com/phase/bookpin/search/preview/BookPreviewViewModel.kt
+++ b/feature/search/src/commonMain/kotlin/com/phase/bookpin/search/preview/BookPreviewViewModel.kt
@@ -21,7 +21,7 @@ class BookPreviewViewModel(
             copy(
                 title = title,
                 author = author,
-                totalPage = totalPage,
+                totalPage = if (totalPage > 0) totalPage.toString() else "",
                 imageUrl = imageUrl,
                 isbn = isbn,
             )
@@ -37,8 +37,7 @@ class BookPreviewViewModel(
     }
 
     fun onTotalPageChange(totalPage: String) {
-        val page = totalPage.toIntOrNull() ?: 0
-        reduce { copy(totalPage = page) }
+        reduce { copy(totalPage = totalPage) }
     }
 
     fun onBackClick() {
@@ -58,7 +57,7 @@ class BookPreviewViewModel(
                     title = state.title,
                     author = state.author,
                     imageUrl = state.imageUrl,
-                    totalPage = state.totalPage,
+                    totalPage = state.totalPage.toInt(),
                 ).onSuccess {
                     postSideEffect(BookPreviewSideEffect.NavigateToHome)
                 }.onFailure { error ->

--- a/feature/settings/src/commonMain/kotlin/com/phase/bookpin/settings/SettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/com/phase/bookpin/settings/SettingsScreen.kt
@@ -50,9 +50,6 @@ fun SettingsScreen(
             SettingsSideEffect.NavigateBack -> onNavigateBack()
             SettingsSideEffect.Logout -> onLogout()
             SettingsSideEffect.DeleteAccount -> onLogout()
-            SettingsSideEffect.NavigateToAllBookmarks -> {
-                // TODO: Navigate to all bookmarks screen
-            }
         }
     }
 
@@ -81,7 +78,6 @@ fun SettingsScreen(
             state.latestBookmark?.let { bookmark ->
                 LatestBookmarkSection(
                     bookmark = bookmark,
-                    onViewAllClick = viewModel::onViewAllBookmarksClick,
                 )
             }
 
@@ -217,7 +213,6 @@ private fun ProfileCard(
 @Composable
 private fun LatestBookmarkSection(
     bookmark: LatestBookmark,
-    onViewAllClick: () -> Unit,
 ) {
     Column(
         modifier = Modifier
@@ -228,35 +223,11 @@ private fun LatestBookmarkSection(
             ).padding(16.dp),
         verticalArrangement = Arrangement.spacedBy(12.dp),
     ) {
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            Text(
-                text = stringResource(Res.string.achievements_title),
-                style = BookPinTheme.typography.bodyMedium,
-                color = BookPinTheme.colors.textSecondary,
-            )
-
-            Row(
-                modifier = Modifier.clickable(onClick = onViewAllClick),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(2.dp),
-            ) {
-                Text(
-                    text = stringResource(Res.string.view_all),
-                    style = BookPinTheme.typography.bodySmall,
-                    color = BookPinTheme.colors.textAccentMuted,
-                )
-                Icon(
-                    painter = painterResource(Res.drawable.ic_chevron_right),
-                    contentDescription = null,
-                    modifier = Modifier.size(14.dp),
-                    tint = BookPinTheme.colors.textAccentMuted,
-                )
-            }
-        }
+        Text(
+            text = stringResource(Res.string.achievements_title),
+            style = BookPinTheme.typography.bodyMedium,
+            color = BookPinTheme.colors.textSecondary,
+        )
 
         LatestBookmarkCard(bookmark = bookmark)
     }
@@ -310,13 +281,6 @@ private fun LatestBookmarkCard(
                 overflow = TextOverflow.Ellipsis,
             )
         }
-
-        Icon(
-            painter = painterResource(Res.drawable.ic_chevron_right),
-            contentDescription = null,
-            modifier = Modifier.size(16.dp),
-            tint = BookPinTheme.colors.iconDefault,
-        )
     }
 }
 

--- a/feature/settings/src/commonMain/kotlin/com/phase/bookpin/settings/SettingsSideEffect.kt
+++ b/feature/settings/src/commonMain/kotlin/com/phase/bookpin/settings/SettingsSideEffect.kt
@@ -7,5 +7,4 @@ sealed interface SettingsSideEffect {
     data object NavigateBack : SettingsSideEffect
     data object Logout : SettingsSideEffect
     data object DeleteAccount : SettingsSideEffect
-    data object NavigateToAllBookmarks : SettingsSideEffect
 }

--- a/feature/settings/src/commonMain/kotlin/com/phase/bookpin/settings/SettingsViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/com/phase/bookpin/settings/SettingsViewModel.kt
@@ -54,11 +54,6 @@ class SettingsViewModel(
         postSideEffect(SettingsSideEffect.ShowSnackbar("문의하기 기능은 준비 중입니다."))
     }
 
-    fun onViewAllBookmarksClick() {
-        // TODO: Navigate to all bookmarks screen when available
-        postSideEffect(SettingsSideEffect.NavigateToAllBookmarks)
-    }
-
     fun onLogoutClick() {
         reduce { copy(showLogoutDialog = true) }
     }

--- a/model/src/commonMain/kotlin/com/phase/bookpin/model/book/BookItem.kt
+++ b/model/src/commonMain/kotlin/com/phase/bookpin/model/book/BookItem.kt
@@ -8,5 +8,8 @@ data class BookItem(
     val totalPage: Int,
     val currentPage: Int,
     val progress: Double,
-    val bookmarkCount: Int
-)
+    val bookmarkCount: Int,
+) {
+    val isCompleted: Boolean
+        get() = progress >= 100.0
+}

--- a/model/src/commonMain/kotlin/com/phase/bookpin/model/book/BookItem.kt
+++ b/model/src/commonMain/kotlin/com/phase/bookpin/model/book/BookItem.kt
@@ -10,6 +10,5 @@ data class BookItem(
     val progress: Double,
     val bookmarkCount: Int,
 ) {
-    val isCompleted: Boolean
-        get() = progress >= 100.0
+    val isCompleted: Boolean = totalPage == currentPage
 }

--- a/model/src/commonMain/kotlin/com/phase/bookpin/model/book/Bookmark.kt
+++ b/model/src/commonMain/kotlin/com/phase/bookpin/model/book/Bookmark.kt
@@ -7,4 +7,5 @@ data class Bookmark(
     val extractedText: String,
     val note: String,
     val imageUrl: String,
+    val createdAt: String,
 )


### PR DESCRIPTION
## 1. 📄 관련된 이슈 및 소개
- 관련 이슈: closes #67
- 소개: 피그마 디자인에 맞춰 완독 책 UI 처리, 페이지 수 빈값 UX 개선, 홈 책갈피 네비게이션 연결, 설정 화면 미지원 기능 제거

## 2. 🔥 변경된 점
- **완독 UI 처리**: `BookItem`에 `isCompleted` computed property 추가, `BookItemCard`에 완독 뱃지(`CompletedBadge`) 및 진행률 텍스트 분기 적용
- **페이지 수 빈값 UX 개선**: `BookDetailScreen`에서 총 페이지가 0일 때의 UX 처리, `BookPreviewScreen`/`BookPreviewState`에서 페이지 수 빈값 입력 대응
- **홈 책갈피 네비게이션 연결**: `HomeScreen`에서 책갈피 남기기 클릭 시 네비게이션 연결
- **설정 화면 미지원 기능 제거**: `SettingsScreen`에서 전체 보기, chevron 아이콘 등 미지원 UI 요소 제거

## 3. ✅ 필수 체크 사항
- [ ] 빌드 확인
- [ ] 테스트 확인
- [ ] 코드 리뷰 요청

## 4. 📸 작업물 사진 공유(선택)

## 5. 💡 알게된 혹은 궁금한 사항
- `CompletedBadge`를 별도 Composable 함수로 분리하여 재사용성 확보