### PR TITLE
#69 : 설정 화면 문의하기 기능 구현 (카카오 채널 연결)

### DIFF
--- a/feature/settings/src/commonMain/kotlin/com/phase/bookpin/settings/SettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/com/phase/bookpin/settings/SettingsScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -43,11 +44,13 @@ fun SettingsScreen(
     val viewModel: SettingsViewModel = koinViewModel()
     val state by viewModel.uiState.collectAsStateWithLifecycle()
     val snackbarHost = LocalSnackbarHost.current
+    val uriHandler = LocalUriHandler.current
 
     viewModel.sideEffect.collectSideEffect {
         when (it) {
             is SettingsSideEffect.ShowSnackbar -> snackbarHost.showSnackbar(it.message)
             SettingsSideEffect.NavigateBack -> onNavigateBack()
+            SettingsSideEffect.OpenContact -> uriHandler.openUri(KAKAO_CHANNEL_URL)
             SettingsSideEffect.Logout -> onLogout()
             SettingsSideEffect.DeleteAccount -> onLogout()
         }
@@ -399,3 +402,5 @@ private fun DeleteAccountItem(
         )
     }
 }
+
+private const val KAKAO_CHANNEL_URL = "http://pf.kakao.com/_UjUuX"

--- a/feature/settings/src/commonMain/kotlin/com/phase/bookpin/settings/SettingsSideEffect.kt
+++ b/feature/settings/src/commonMain/kotlin/com/phase/bookpin/settings/SettingsSideEffect.kt
@@ -5,6 +5,7 @@ sealed interface SettingsSideEffect {
         val message: String,
     ) : SettingsSideEffect
     data object NavigateBack : SettingsSideEffect
+    data object OpenContact : SettingsSideEffect
     data object Logout : SettingsSideEffect
     data object DeleteAccount : SettingsSideEffect
 }

--- a/feature/settings/src/commonMain/kotlin/com/phase/bookpin/settings/SettingsViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/com/phase/bookpin/settings/SettingsViewModel.kt
@@ -51,7 +51,7 @@ class SettingsViewModel(
     }
 
     fun onContactClick() {
-        postSideEffect(SettingsSideEffect.ShowSnackbar("문의하기 기능은 준비 중입니다."))
+        postSideEffect(SettingsSideEffect.OpenContact)
     }
 
     fun onLogoutClick() {


### PR DESCRIPTION
## 1. 📄 관련된 이슈 및 소개
- 관련 이슈: closes #69
- 소개: 설정 화면의 문의하기 버튼을 눌렀을 때 카카오 채널로 이동하도록 구현

## 2. 🔥 변경된 점
- `SettingsSideEffect`에 `OpenContact` 사이드이펙트 추가
- `SettingsViewModel`의 `onContactClick()`에서 기존 "준비 중" 스낵바 대신 `OpenContact` 사이드이펙트 발행
- `SettingsScreen`에서 `LocalUriHandler`를 사용하여 카카오 채널 URL(`http://pf.kakao.com/_UjUuX`) 열기

## 3. ✅ 필수 체크 사항
- [x] 빌드 확인
- [ ] 테스트 확인
- [ ] 코드 리뷰 요청

## 4. 📸 작업물 사진 공유(선택)

## 5. 💡 알게된 혹은 궁금한 사항
- Compose Multiplatform의 `LocalUriHandler`를 사용하여 expect/actual 없이 Android/iOS 양 플랫폼에서 외부 URL 열기 처리